### PR TITLE
Modal & inputRow updates

### DIFF
--- a/docs/Examples/Input.example.purs
+++ b/docs/Examples/Input.example.purs
@@ -11,6 +11,7 @@ import Lumi.Components.Row (row_)
 import Lumi.Components.Text (body_, h2_, h4_, p_)
 import Lumi.Components.Example (example)
 import React.Basic (JSX)
+import React.Basic.DOM as R
 
 docs :: JSX
 docs =
@@ -85,16 +86,16 @@ docs =
     , h4_ "Left aligned"
 
     , example
-        $ inputRow "Field label" true checkbox { checked = Off }
+        $ inputRow { labelText: "Field label", leftAligned: true, style: R.css {} } checkbox { checked = Off }
 
     , example
-        $ inputRow "Field label" true checkbox
+        $ inputRow { labelText: "Field label", leftAligned: true, style: R.css {} } checkbox
             { size = Small
             , checked = Off
             }
 
     , example
-        $ inputRow "Field label" true radio { checked = Off }
+        $ inputRow { labelText: "Field label", leftAligned: true, style: R.css {} } radio { checked = Off }
 
 
     , h2_ "Checkbox"

--- a/docs/Examples/Input.example.purs
+++ b/docs/Examples/Input.example.purs
@@ -6,7 +6,7 @@ import Data.Maybe (Maybe(Just))
 import Data.Nullable (toNullable)
 import Lumi.Components.Size (Size(..))
 import Lumi.Components.Column (column_)
-import Lumi.Components.Input (CheckboxState(..), alignToInput, checkbox, input, inputRow, radio, range, switch, text_)
+import Lumi.Components.Input (CheckboxState(..), alignToInput, checkbox, input, inputRow, inputRow_, radio, range, switch, text_)
 import Lumi.Components.Row (row_)
 import Lumi.Components.Text (body_, h2_, h4_, p_)
 import Lumi.Components.Example (example)
@@ -71,16 +71,16 @@ docs =
     , h4_ "Padded"
 
     , example
-        $ inputRow "Field label" false checkbox { checked = Off }
+        $ inputRow_ "Field label" checkbox { checked = Off }
 
     , example
-        $ inputRow "Field label" false checkbox
+        $ inputRow_ "Field label" checkbox
             { size = Small
             , checked = Off
             }
 
     , example
-        $ inputRow "Field label" false radio { checked = Off }
+        $ inputRow_ "Field label" radio { checked = Off }
 
     , h4_ "Left aligned"
 
@@ -101,34 +101,34 @@ docs =
 
     , h4_ "Medium"
     , example
-        $ inputRow "Field label" false checkbox { checked = Off }
+        $ inputRow_ "Field label" checkbox { checked = Off }
 
 
     , example
-        $ inputRow "Field label" false checkbox { checked = On }
+        $ inputRow_ "Field label" checkbox { checked = On }
 
 
     , example
-        $ inputRow "Field label" false checkbox { checked = Indeterminate }
+        $ inputRow_ "Field label" checkbox { checked = Indeterminate }
 
 
     , h4_ "Small"
     , example
-        $ inputRow "Field label" false checkbox
+        $ inputRow_ "Field label" checkbox
             { size = Small
             , checked = Off
             }
 
 
     , example
-        $ inputRow "Field label" false checkbox
+        $ inputRow_ "Field label" checkbox
             { size = Small
             , checked = On
             }
 
 
     , example
-        $ inputRow "Field label" false checkbox
+        $ inputRow_ "Field label" checkbox
             { size = Small
             , checked = Indeterminate
             }
@@ -138,23 +138,23 @@ docs =
 
     , h4_ "Medium"
     , example
-        $ inputRow "Field label" false radio { checked = Off }
+        $ inputRow_ "Field label" radio { checked = Off }
 
 
     , example
-        $ inputRow "Field Label" false radio { checked = On }
+        $ inputRow_ "Field Label" radio { checked = On }
 
 
     , h4_ "Small"
     , example
-        $ inputRow "Field Label" false radio
+        $ inputRow_ "Field Label" radio
             { size = Small
             , checked = Off
             }
 
 
     , example
-        $ inputRow "Field label" false radio
+        $ inputRow_ "Field label" radio
             { size = Small
             , checked = On
             }

--- a/docs/Examples/Input.example.purs
+++ b/docs/Examples/Input.example.purs
@@ -66,38 +66,69 @@ docs =
             ]
 
 
+    , h2_ "Input Row"
+
+    , h4_ "Padded"
+
+    , example
+        $ inputRow "Field label" false checkbox { checked = Off }
+
+    , example
+        $ inputRow "Field label" false checkbox
+            { size = Small
+            , checked = Off
+            }
+
+    , example
+        $ inputRow "Field label" false radio { checked = Off }
+
+    , h4_ "Left aligned"
+
+    , example
+        $ inputRow "Field label" true checkbox { checked = Off }
+
+    , example
+        $ inputRow "Field label" true checkbox
+            { size = Small
+            , checked = Off
+            }
+
+    , example
+        $ inputRow "Field label" true radio { checked = Off }
+
+
     , h2_ "Checkbox"
 
     , h4_ "Medium"
     , example
-        $ inputRow "Field label" checkbox { checked = Off }
+        $ inputRow "Field label" false checkbox { checked = Off }
 
 
     , example
-        $ inputRow "Field label" checkbox { checked = On }
+        $ inputRow "Field label" false checkbox { checked = On }
 
 
     , example
-        $ inputRow "Field label" checkbox { checked = Indeterminate }
+        $ inputRow "Field label" false checkbox { checked = Indeterminate }
 
 
     , h4_ "Small"
     , example
-        $ inputRow "Field label" checkbox
+        $ inputRow "Field label" false checkbox
             { size = Small
             , checked = Off
             }
 
 
     , example
-        $ inputRow "Field label" checkbox
+        $ inputRow "Field label" false checkbox
             { size = Small
             , checked = On
             }
 
 
     , example
-        $ inputRow "Field label" checkbox
+        $ inputRow "Field label" false checkbox
             { size = Small
             , checked = Indeterminate
             }
@@ -107,23 +138,23 @@ docs =
 
     , h4_ "Medium"
     , example
-        $ inputRow "Field label" radio { checked = Off }
+        $ inputRow "Field label" false radio { checked = Off }
 
 
     , example
-        $ inputRow "Field Label" radio { checked = On }
+        $ inputRow "Field Label" false radio { checked = On }
 
 
     , h4_ "Small"
     , example
-        $ inputRow "Field Label" radio
+        $ inputRow "Field Label" false radio
             { size = Small
             , checked = Off
             }
 
 
     , example
-        $ inputRow "Field label" radio
+        $ inputRow "Field label" false radio
             { size = Small
             , checked = On
             }

--- a/docs/Examples/Modal.example.purs
+++ b/docs/Examples/Modal.example.purs
@@ -18,6 +18,7 @@ data ModalTestId
   = SmallModal
   | MediumModal
   | LargeModal
+  | ExtraLargeModal
   | DialogModal
   | LongModal
   | ErrorModal
@@ -102,6 +103,35 @@ docs = unit # make component
               , actionButtonDisabled: false
               , size: Large
               , title: "Modal title -- Large"
+              , variant: ""
+              , internalBorders: false
+              , children:
+                  fragment
+                    [ body_ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium nec tellus ornare tincidunt. Phasellus ultrices porta finibus. In id mollis diam. Praesent efficitur lectus quis odio convallis placerat. Suspendisse metus tortor, faucibus nec imperdiet quis, iaculis id risus. Pellentesque a auctor turpis, a lacinia nulla. Pellentesque malesuada suscipit ante, sed convallis est pharetra eu. In sed enim nec lacus dignissim malesuada. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In metus arcu, efficitur et magna a, fermentum lacinia nulla. Mauris ligula erat, posuere sed diam a, sodales vestibulum ante."
+                    , body_ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium nec tellus ornare tincidunt. Phasellus ultrices porta finibus. In id mollis diam. Praesent efficitur lectus quis odio convallis placerat. Suspendisse metus tortor, faucibus nec imperdiet quis, iaculis id risus. Pellentesque a auctor turpis, a lacinia nulla. Pellentesque malesuada suscipit ante, sed convallis est pharetra eu. In sed enim nec lacus dignissim malesuada. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In metus arcu, efficitur et magna a, fermentum lacinia nulla. Mauris ligula erat, posuere sed diam a, sodales vestibulum ante."
+                    , body_ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium nec tellus ornare tincidunt. Phasellus ultrices porta finibus. In id mollis diam. Praesent efficitur lectus quis odio convallis placerat. Suspendisse metus tortor, faucibus nec imperdiet quis, iaculis id risus. Pellentesque a auctor turpis, a lacinia nulla. Pellentesque malesuada suscipit ante, sed convallis est pharetra eu. In sed enim nec lacus dignissim malesuada. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In metus arcu, efficitur et magna a, fermentum lacinia nulla. Mauris ligula erat, posuere sed diam a, sodales vestibulum ante."
+                    , body_ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium nec tellus ornare tincidunt. Phasellus ultrices porta finibus. In id mollis diam. Praesent efficitur lectus quis odio convallis placerat. Suspendisse metus tortor, faucibus nec imperdiet quis, iaculis id risus. Pellentesque a auctor turpis, a lacinia nulla. Pellentesque malesuada suscipit ante, sed convallis est pharetra eu. In sed enim nec lacus dignissim malesuada. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In metus arcu, efficitur et magna a, fermentum lacinia nulla. Mauris ligula erat, posuere sed diam a, sodales vestibulum ante."
+                    , body_ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium nec tellus ornare tincidunt. Phasellus ultrices porta finibus. In id mollis diam. Praesent efficitur lectus quis odio convallis placerat. Suspendisse metus tortor, faucibus nec imperdiet quis, iaculis id risus. Pellentesque a auctor turpis, a lacinia nulla. Pellentesque malesuada suscipit ante, sed convallis est pharetra eu. In sed enim nec lacus dignissim malesuada. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In metus arcu, efficitur et magna a, fermentum lacinia nulla. Mauris ligula erat, posuere sed diam a, sodales vestibulum ante."
+                    , body_ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pretium nec tellus ornare tincidunt. Phasellus ultrices porta finibus. In id mollis diam. Praesent efficitur lectus quis odio convallis placerat. Suspendisse metus tortor, faucibus nec imperdiet quis, iaculis id risus. Pellentesque a auctor turpis, a lacinia nulla. Pellentesque malesuada suscipit ante, sed convallis est pharetra eu. In sed enim nec lacus dignissim malesuada. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In metus arcu, efficitur et magna a, fermentum lacinia nulla. Mauris ligula erat, posuere sed diam a, sodales vestibulum ante."
+                    ]
+              }
+
+        , example $
+            button secondary
+              { onPress = capture_ $ self.setState _ { modalId = Just ExtraLargeModal }
+              , title = "Open modal, extra large"
+              }
+
+        , guard (self.state.modalId == Just ExtraLargeModal) $
+            modal
+              { modalOpen: true
+              , closeButton: true
+              , onRequestClose: self.setState _ { modalId = Nothing }
+              , onActionButtonClick: notNull $ self.setState \state -> state { clicks = state.clicks + 1 }
+              , actionButtonTitle: "Add clicks"
+              , actionButtonDisabled: false
+              , size: ExtraLarge
+              , title: "Modal title -- Extra Large"
               , variant: ""
               , internalBorders: false
               , children:

--- a/src/Lumi/Components/Input.purs
+++ b/src/Lumi/Components/Input.purs
@@ -283,19 +283,22 @@ label_ children = label
   , style: R.css {}
   }
 
-inputRow :: String -> Boolean -> InputProps -> JSX
-inputRow labelText leftAligned opts = label
-  { style: css { flexDirection: "row" }
+inputRow :: { labelText :: String, leftAligned :: Boolean, style :: CSS } -> InputProps -> JSX
+inputRow props opts = label
+  { style: R.mergeStyles
+            [ props.style
+            , R.css { flexDirection: "row" }
+            ]
   , for: toNullable Nothing
   , children:
-      [ input opts { style = css { marginRight: 8, marginLeft: if leftAligned then 0 else 8 } }
-      , alignToInput $ body_ labelText
+      [ input opts { style = css { marginRight: 8, marginLeft: if props.leftAligned then 0 else 8 } }
+      , alignToInput $ body_ props.labelText
       ]
   }
 
 inputRow_ :: String -> InputProps -> JSX
 inputRow_ labelText opts =
-  inputRow labelText false opts
+  inputRow { labelText: labelText, leftAligned: false, style: R.css { flexDirection: "row" } } opts
 
 alignToInputComponent :: Component JSX
 alignToInputComponent = createComponent "AlignToInput"

--- a/src/Lumi/Components/Input.purs
+++ b/src/Lumi/Components/Input.purs
@@ -345,6 +345,7 @@ styles = jss
               , display: "flex"
               , justifyContent: "center"
               , alignItems: "center"
+              , flexShrink: "0"
               , padding: "0"
               , color: cssStringHSLA colors.white
               , backgroundColor: cssStringHSLA colors.white
@@ -596,6 +597,7 @@ styles = jss
           , display: "flex"
           , flexFlow: "row"
           , alignItems: "center"
+          , flexShrink: "1"
           , fontSize: "14px"
           , lineHeight: "20px"
           , padding: inputAlignToPadding

--- a/src/Lumi/Components/Input.purs
+++ b/src/Lumi/Components/Input.purs
@@ -31,6 +31,7 @@ module Lumi.Components.Input
   , label
   , label_
   , inputRow
+  , inputRow_
   , alignToInput
   , styles
   , lumiInputStyles
@@ -291,6 +292,10 @@ inputRow labelText leftAligned opts = label
       , alignToInput $ body_ labelText
       ]
   }
+
+inputRow_ :: String -> InputProps -> JSX
+inputRow_ labelText opts =
+  inputRow labelText false opts
 
 alignToInputComponent :: Component JSX
 alignToInputComponent = createComponent "AlignToInput"

--- a/src/Lumi/Components/Input.purs
+++ b/src/Lumi/Components/Input.purs
@@ -291,7 +291,13 @@ inputRow props opts = label
             ]
   , for: toNullable Nothing
   , children:
-      [ input opts { style = css { marginRight: 8, marginLeft: if props.leftAligned then 0 else 8 } }
+      [ input opts
+          { style =
+              R.mergeStyles
+                [ opts.style
+                , css { marginRight: 8, marginLeft: if props.leftAligned then 0 else 8 }
+                ]
+          }
       , alignToInput $ body_ props.labelText
       ]
   }

--- a/src/Lumi/Components/Input.purs
+++ b/src/Lumi/Components/Input.purs
@@ -282,12 +282,12 @@ label_ children = label
   , style: R.css {}
   }
 
-inputRow :: String -> InputProps -> JSX
-inputRow labelText opts = label
+inputRow :: String -> Boolean -> InputProps -> JSX
+inputRow labelText leftAligned opts = label
   { style: css { flexDirection: "row" }
   , for: toNullable Nothing
   , children:
-      [ input opts { style = css { marginRight: 8 } }
+      [ input opts { style = css { marginRight: 8, marginLeft: if leftAligned then 0 else 8 } }
       , alignToInput $ body_ labelText
       ]
   }

--- a/src/Lumi/Components/Modal.purs
+++ b/src/Lumi/Components/Modal.purs
@@ -348,6 +348,9 @@ styles = jss
                   , "&[data-size=\"large\"]":
                       { width: "60rem"
                       }
+                  , "&[data-size=\"extra-large\"]":
+                      { width: "84.8rem"
+                      }
                   , maxWidth: "calc(100vw - (2.4rem * 2))"
                   , background: "rgba(255, 255, 255, 1)"
                   , borderRadius: "0.4rem"


### PR DESCRIPTION
- Add flex-shrink rules re a checkbox input within an `inputRow`; allow for `inputRow` to left align inputs.
- Add `ExtraLarge` `modal` size

**!Note: this is a breaking change re `inputRow` vs. `inputRow_` **