### PR TITLE
Fix buttonGroup child margin

### DIFF
--- a/src/Lumi/Components/ButtonGroup.purs
+++ b/src/Lumi/Components/ButtonGroup.purs
@@ -1,5 +1,7 @@
 module Lumi.Components.ButtonGroup where
 
+import Prelude
+
 import JSS (JSS, jss)
 import Lumi.Components.ZIndex (ziButtonGroup)
 import React.Basic (Component, JSX, createComponent, element, makeStateless)
@@ -21,10 +23,14 @@ buttonGroup = makeStateless component render
       buttonGroupElement
         { "data-joined": props.joined
         , style: props.style
-        , children: props.children
+        , children: map renderChild props.children
         }
+      where
+        renderChild child =
+          buttonGroupChildElement { children: [ child ] }
 
     buttonGroupElement = element (unsafeCreateDOMComponent "lumi-button-group")
+    buttonGroupChildElement = element (unsafeCreateDOMComponent "lumi-button-group-child")
 
 styles :: JSS
 styles = jss
@@ -34,12 +40,12 @@ styles = jss
           , display: "flex"
           , flexFlow: "row"
 
-          , "&[data-joined=false] > *":
+          , "&[data-joined=false] > lumi-button-group-child":
               { marginRight: "10px"
               , "&:last-child": { marginRight: "0" }
               }
 
-          , "&[data-joined=true] > *":
+          , "&[data-joined=true] > lumi-button-group-child":
               { "&:not(:last-child)":
                   { marginRight: "-1px"
                   , borderTopRightRadius: "0"


### PR DESCRIPTION
Add container element to `ButtonGroup` children to support margin style rules.

<img width="280" alt="Screen Shot 2019-04-26 at 11 24 52 AM" src="https://user-images.githubusercontent.com/632981/56828446-2f153900-6816-11e9-9759-84e90b2b39d9.png">

Fixes:
<img width="326" alt="Screen Shot 2019-04-26 at 9 53 06 AM" src="https://user-images.githubusercontent.com/632981/56828436-2b81b200-6816-11e9-82e8-e9c25b218c32.png">

