### PR TITLE
Fix Loader.purs JSS content attribute

### DIFF
--- a/src/Lumi/Components/Loader.purs
+++ b/src/Lumi/Components/Loader.purs
@@ -40,7 +40,7 @@ styles = jss
 spinnerMixin :: { radius :: String, borderWidth :: String } -> JSS
 spinnerMixin { radius, borderWidth } = jss
   { boxSizing: "border-box"
-  , content: ""
+  , content: "\"\""
   , display: "inline-block"
   , height: radius
   , width: radius


### PR DESCRIPTION
This appears to fix #25 by adding an escaped empty string to `content` JSS prop, so the computed CSS value is `content: ""`.

![Screen Shot 2019-05-10 at 9 22 50 AM](https://user-images.githubusercontent.com/26548438/57542069-6fd87c00-7305-11e9-8d06-f7148a338da1.png)

![Screen Shot 2019-05-10 at 9 19 54 AM](https://user-images.githubusercontent.com/26548438/57541932-0f493f00-7305-11e9-9f8e-c0443c935913.png)