### PR TITLE
Remove old "build" interpreter functions from the Form DSL

### DIFF
--- a/src/Lumi/Components/Form/Defaults.purs
+++ b/src/Lumi/Components/Form/Defaults.purs
@@ -10,7 +10,7 @@ import Prelude
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Symbol (class IsSymbol, SProxy(..))
-import Lumi.Components.Form (Validated(..))
+import Lumi.Components.Form.Validation (Validated(..))
 import Prim.Row (class Cons, class Lacks)
 import Prim.RowList (class RowToList, Cons, Nil)
 import Record.Builder (Builder)

--- a/src/Lumi/Components/Wizard.purs
+++ b/src/Lumi/Components/Wizard.purs
@@ -63,7 +63,7 @@ step
   ~> Wizard step { readonly :: Boolean | props } value
 step s f =
   let
-    form = F.buildConcurrently f
+    form = F.build f
   in
     Wizard $ liftF $ Form
       { step: s


### PR DESCRIPTION
Replace `Form.build` with `Form.buildConcurrently`
Remove `Form.buildWithDefaults`