### PR TITLE
Fix components remounting in parallel/sequential wrappers

### DIFF
--- a/src/Lumi/Components/Form.purs
+++ b/src/Lumi/Components/Form.purs
@@ -159,8 +159,10 @@ buildConcurrently editor = makeStateless (createComponent "Form") render where
           Child { key, child } ->
             maybe identity keyed key $ child
           Wrapper { key, children } ->
-            maybe identity keyed key $
-              fragment [ intercalate fieldDivider (map toRow children) ]
+            R.div
+              { key: fromMaybe "" key
+              , children: [ intercalate fieldDivider (map toRow children) ]
+              }
           Node { label, key, required, validationError, children } ->
             maybe identity keyed key $ labeledField
               { label: text body


### PR DESCRIPTION
If you go to https://lumihq.github.io/purescript-lumi-components/#/form and type in anything inside the `Password` field, the focus is lost, as the component is getting remounted.

Presumably this happens because `keyed <<< fragment` does not work properly. This was solved by replacing this in the case for `Wrapper` form trees with a `div` with a key.