### PR TITLE
Fix bottom padding of inlineTable forms inside other forms

### DIFF
--- a/src/Lumi/Components/Form.purs
+++ b/src/Lumi/Components/Form.purs
@@ -949,17 +949,6 @@ styles = jss
               { "&:first-child, &:last-child": { display: "none" }
               }
 
-            -- not InlineTable Form rules
-          , "&:not(.inline-table)":
-              { "& .labeled-field":
-                  { paddingBottom: "16px"
-
-                  , "&[data-force-top-label=\"true\"] lumi-align-to-input":
-                      { padding: "0 0 4px 0"
-                      }
-                  }
-              }
-
           , "&.readonly label.lumi":
               { cursor: "auto"
               , userSelect: "auto"
@@ -972,10 +961,25 @@ styles = jss
               , "&:hover": { textDecoration: "underline" }
               }
 
+            -- not InlineTable Form rules
+          , "& .labeled-field":
+              { paddingBottom: "16px"
+
+              , "&[data-force-top-label=\"true\"] lumi-align-to-input":
+                  { padding: "0 0 4px 0"
+                  }
+              }
+
           , "&.inline-table":
               { -- If necessary, override the not(.inline-table)
                 -- rule above (for nested forms)
-                "& .labeled-field": { paddingBottom: "0" }
+                "& .labeled-field":
+                  { paddingBottom: "0"
+
+                  , "&[data-force-top-label=\"true\"] lumi-align-to-input":
+                      { padding: "0"
+                      }
+                  }
 
               , "& hr.lumi.field-divider":
                   { height: "0.1rem"


### PR DESCRIPTION
The screenshots below were produced by building and inserting `addressForm` with `inlineTable: true` as a form field inside `userForm`.

### Before
![Screen Shot 2019-05-24 at 16 39 41](https://user-images.githubusercontent.com/2164548/58352714-cd5ee380-7e42-11e9-9d92-e1b7a03706f9.png)

### After
![Screen Shot 2019-05-24 at 16 38 53](https://user-images.githubusercontent.com/2164548/58352704-c89a2f80-7e42-11e9-955a-45bdefcd334f.png)
