### PR TITLE
Update README.md to prepare for publishing to Pursuit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # purescript-lumi-components [![Build Status](https://travis-ci.org/lumihq/purescript-lumi-components.svg?branch=master)](https://travis-ci.org/lumihq/purescript-lumi-components)
 
-[lumihq.github.io/purescript-lumi-components](https://lumihq.github.io/purescript-lumi-components/)
+- [lumihq.github.io/purescript-lumi-components](https://lumihq.github.io/purescript-lumi-components/)
+- [purescript-lumi-components on Pursuit](https://pursuit.purescript.org/packages/purescript-lumi-components/)
 
 This is a component library focused on Lumi's specific UI and UX needs. Available components are found in `src/components`.
 
@@ -32,7 +33,7 @@ You can run production builds (output minified, static files to `build/`) using 
 
 ```sh
 pulp version 0.x.y
-git push --follow-tags
+pulp publish
 npm run deploy
 ```
 


### PR DESCRIPTION
Closes #40

The new link I've added currently 404ing, since `purescript-lumi-components` isn't on Pursuit yet, but once this is merged I'll publish to Pursuit so that the link works.