### PR TITLE
Remove "postbuild" step

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "build:purs": "pulp build -I docs",
     "pscid": "pscid -I docs",
     "pscid:build": "run-s build:purs",
-    "postbuild": "pulp docs",
     "predeploy": "run-s build",
     "deploy": "gh-pages -d build",
     "clean": "rm -rf build output generated-docs .psa-stash .pulp-cache .psci-modules",


### PR DESCRIPTION
`pulp docs` now fails because the `--docgen` option to purs docs has
been removed. Now that we no longer check markdown docs into the repo,
there's not much reason to keep this, especially since it makes the
`npm run deploy` script fail.