### PR TITLE
[#60 ] remove override of input & select styles within a Table

### DIFF
--- a/docs/Examples/Table.example.purs
+++ b/docs/Examples/Table.example.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Monad.Except (runExcept)
 import Data.Array as Array
 import Data.Either (Either(..))
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (un)
 import Data.Nullable (notNull, null, toMaybe, toNullable)
 import Effect.Console (log)
@@ -14,8 +14,10 @@ import Foreign (readString, unsafeToForeign)
 import Foreign.Index (readProp)
 import Lumi.Components.Column (column, column_)
 import Lumi.Components.Images (productThumb_)
+import Lumi.Components.Input (input, text_)
 import Lumi.Components.Link as Link
 import Lumi.Components.Lockup (lockup)
+import Lumi.Components.NativeSelect (defaults, nativeSelect)
 import Lumi.Components.Size (Size(..))
 import Lumi.Components.Table (ColumnName(..), SortString(..), table)
 import Lumi.Components.Text (p_)
@@ -23,6 +25,8 @@ import Lumi.Components.Example (example)
 import React.Basic (Component, JSX, createComponent, make)
 import React.Basic.DOM (css)
 import React.Basic.DOM as R
+import React.Basic.DOM.Events (targetValue)
+import React.Basic.Events (handler)
 import Web.HTML.History (URL(..))
 
 component :: Component Unit
@@ -35,6 +39,7 @@ docs = unit # make component { initialState, render }
       { sort: SortString "asc"
       , sortBy: Just (ColumnName "createdDate")
       , selected: ["10cms9", "0mf7w"]
+      , selectedOption: ""
       , ex2Columns:
           [ { required: true
             , name: ColumnName "product-type"
@@ -61,12 +66,24 @@ docs = unit # make component { initialState, render }
             , renderCell: \rowData -> R.text rowData.createdDate
             }
           ]
+      , ex3Columns:
+          [ { required: true
+            , name: ColumnName "input"
+            , label: notNull "Input"
+            , filterLabel: null
+            , sortBy: null
+            , style: css {}
+            , hidden: false
+            , sticky: false
+            , renderCell: \rowData ->
+                input text_ { placeholder = "Placeholder..." }
+            }
+          ]
       }
 
     render self =
       column_
         [ p_ "*Right click on table header to see FilterDropdownMenu"
-
         , example $
             column
               { style: css { alignSelf: "stretch" , height: 150, width: 400 }
@@ -141,6 +158,7 @@ docs = unit # make component { initialState, render }
                   ]
               }
 
+        , p_ "*Does not include FilterDropdownMenu"
         , example $
             column
               { style: css { alignSelf: "stretch" }
@@ -179,6 +197,78 @@ docs = unit # make component { initialState, render }
                           , sticky: false
                           }
                       , columns: self.state.ex2Columns
+                      , onColumnChange: notNull $ mkEffectFn1 \columns ->
+                          self.setState _ { ex2Columns = columns }
+                      }
+                  ]
+              }
+
+        , p_ "*Non selectable variant w/ inputs & selects"
+        , example $
+            column
+              { style: css { alignSelf: "stretch" }
+              , children:
+                  [ table
+                      { name: "Items"
+                      , dropdownMenu: true
+                      , sortable: true
+                      , sort: notNull self.state.sort
+                      , sortBy: toNullable self.state.sortBy
+                      , updateSort: mkEffectFn2 \sort sortBy -> do
+                          self.setState _ { sort = sort, sortBy = toMaybe sortBy }
+                      , selectable: false
+                      , selected: null
+                      , onSelect: mkEffectFn1 \selected -> self.setState _ { selected = selected }
+                      , rows: (if self.state.sort == SortString "desc" then Array.reverse else identity)
+                          let tableFieldSort = comparing \row -> do
+                                ColumnName sortByCol <- self.state.sortBy
+                                case runExcept $ readString =<< readProp sortByCol (unsafeToForeign row) of
+                                  Right value -> Just value
+                                  _           -> Nothing
+                          in Array.sortBy tableFieldSort tableData
+                      , getRowKey: _.id
+                      , rowEq: eq
+                      , onNavigate: mkEffectFn1 \href ->
+                          log $ "navigate to: " <> un URL href
+                      , variant: notNull "compact"
+                      , primaryColumn: notNull
+                          { name: ColumnName "product-title"
+                          , label: notNull "Items"
+                          , filterLabel: notNull "Product title"
+                          , sortBy: null
+                          , style: css {}
+                          , getLink: _.link
+                          , renderCell: R.text <<< _.title
+                          , sticky: false
+                          }
+                      , columns:
+                          Array.concat
+                            [ self.state.ex2Columns
+                            , self.state.ex3Columns
+                            , [ { required: true
+                                , name: ColumnName "select"
+                                , label: notNull "Select"
+                                , filterLabel: null
+                                , sortBy: null
+                                , style: css {}
+                                , hidden: false
+                                , sticky: false
+                                , renderCell: \rowData ->
+                                    nativeSelect defaults
+                                        { options =
+                                            [ { label: "Select your car...", value: "" }
+                                            , { label: "Volvo", value: "volvo" }
+                                            , { label: "Saab", value: "saab" }
+                                            , { label: "Mercedes", value: "mercedes" }
+                                            , { label: "Audi", value: "audi" }
+                                            ]
+                                        , onChange = handler targetValue \value ->
+                                                      self.setState _ { selectedOption = fromMaybe "" value }
+                                        , value = self.state.selectedOption
+                                        }
+                                }
+                              ]
+                            ]
                       , onColumnChange: notNull $ mkEffectFn1 \columns ->
                           self.setState _ { ex2Columns = columns }
                       }

--- a/src/Lumi/Components/Table.purs
+++ b/src/Lumi/Components/Table.purs
@@ -700,12 +700,6 @@ styles = jss
                           { color: cssStringHSLA colors.primary
                           }
                       }
-                  , "& input.lumi:not([type=\"checkbox\"]), & select.lumi":
-                      { border: "none"
-                      , paddingTop: "0"
-                      , paddingBottom: "0"
-                      , paddingLeft: "0"
-                      }
                   }
               , "& a.lumi":
                   { color: cssStringHSLA colors.black


### PR DESCRIPTION
Currently our `Table` is overriding our input & select styles; cause `inputs` and `selects` within a table to appear as such:

<img width="1014" alt="Screen Shot 2019-06-13 at 2 13 09 PM" src="https://user-images.githubusercontent.com/632981/59431551-761ab600-8de5-11e9-94ff-9d6510738455.png">

Not sure if we intentionally want our native selects to not include their default styling; selectively only keeping input styles (but not on the native select) would look as such:

<img width="1000" alt="Screen Shot 2019-06-13 at 2 10 55 PM" src="https://user-images.githubusercontent.com/632981/59431594-921e5780-8de5-11e9-9adf-cae0529f6a74.png">

In my opinion, it is better UI for the user to clearly see the input or select within the table, such as:

<img width="1007" alt="Screen Shot 2019-06-13 at 2 06 31 PM" src="https://user-images.githubusercontent.com/632981/59431642-a3fffa80-8de5-11e9-9aaf-a251919feaef.png">
