### PR TITLE
Allow primary columns without getLink

### DIFF
--- a/docs/Examples/Layouts.example.purs
+++ b/docs/Examples/Layouts.example.purs
@@ -6,12 +6,13 @@ import Data.Array (index)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (un)
 import Data.NonEmpty ((:|))
-import Data.Nullable (toNullable)
+import Data.Nullable (notNull, toNullable)
 import Data.String (Pattern(..), split)
 import Effect.Console (log)
 import Effect.Uncurried (mkEffectFn1, mkEffectFn2, runEffectFn1)
 import Lumi.Components.Button (button, defaults)
 import Lumi.Components.Column (column_)
+import Lumi.Components.Example (example)
 import Lumi.Components.Images (avatar_, productThumb_)
 import Lumi.Components.Layouts.Centered as Centered
 import Lumi.Components.Layouts.OneColumnWithHeader as OneColumnWithHeader
@@ -24,7 +25,6 @@ import Lumi.Components.Tab (TabId(..), TabKey(..), urlParts)
 import Lumi.Components.Table (ColumnName(..), table)
 import Lumi.Components.Text (body_, h2_, p_, sectionHeader_)
 import Lumi.Components.Utility.ReactRouter (RouterProps, withRouter)
-import Lumi.Components.Example (example)
 import React.Basic (Component, JSX, createComponent, element, toReactComponent)
 import React.Basic.DOM as R
 import Web.HTML.History (URL(..))
@@ -241,7 +241,7 @@ docs = (\c -> element c {}) $ withRouter $ toReactComponent identity component {
             , filterLabel: toNullable $ Just "Product title"
             , sortBy: toNullable Nothing
             , style: R.css {}
-            , getLink: _.link
+            , getLink: notNull _.link
             , sticky: false
             , renderCell: \rowData ->
                 lockup

--- a/docs/Examples/Table.example.purs
+++ b/docs/Examples/Table.example.purs
@@ -13,13 +13,13 @@ import Effect.Uncurried (mkEffectFn1, mkEffectFn2)
 import Foreign (readString, unsafeToForeign)
 import Foreign.Index (readProp)
 import Lumi.Components.Column (column, column_)
+import Lumi.Components.Example (example)
 import Lumi.Components.Images (productThumb_)
 import Lumi.Components.Link as Link
 import Lumi.Components.Lockup (lockup)
 import Lumi.Components.Size (Size(..))
 import Lumi.Components.Table (ColumnName(..), SortString(..), table)
 import Lumi.Components.Text (p_)
-import Lumi.Components.Example (example)
 import React.Basic (Component, JSX, createComponent, make)
 import React.Basic.DOM (css)
 import React.Basic.DOM as R
@@ -100,7 +100,7 @@ docs = unit # make component { initialState, render }
                           , filterLabel: notNull "Product lockup"
                           , sortBy: null
                           , style: css {}
-                          , getLink: _.link
+                          , getLink: notNull _.link
                           , renderCell: \rowData ->
                               lockup
                                 { image: Just $ productThumb_ { image: R.img { src: rowData.imgSrc }, size: Small }
@@ -174,7 +174,7 @@ docs = unit # make component { initialState, render }
                           , filterLabel: notNull "Product title"
                           , sortBy: null
                           , style: css {}
-                          , getLink: _.link
+                          , getLink: null -- notNull _.link
                           , renderCell: R.text <<< _.title
                           , sticky: false
                           }

--- a/src/Lumi/Components/Table.purs
+++ b/src/Lumi/Components/Table.purs
@@ -312,25 +312,7 @@ table = make component
 
         primaryColumn = cleanUpNullables <$> toMaybe self.props.primaryColumn
           where
-            cleanUpNullables
-              { name
-              , label
-              , filterLabel
-              , sortBy
-              , style
-              , getLink
-              , renderCell
-              , sticky
-              } =
-              { name
-              , label
-              , filterLabel
-              , sortBy
-              , style
-              , getLink: toMaybe getLink
-              , renderCell
-              , sticky
-              }
+            cleanUpNullables x = x { getLink = toMaybe x.getLink }
 
         renderTableHead columns tableRef =
           element (R.unsafeCreateDOMComponent "thead")


### PR DESCRIPTION
Primary columns offer a few features besides row linking, like not being sortable or hideable. This allows the use of these primary column features without entire row linking.