### PR TITLE
Add onBlur handler to close select menu

### DIFF
--- a/src/Lumi/Components/Select.purs
+++ b/src/Lumi/Components/Select.purs
@@ -329,6 +329,7 @@ select = makeStateless component render
                       Ready options_ -> renderOptions options_
                 }
             ]
+        , onBlur: Events.handler_ selectState.closeSelect
         }
         where
           renderOptions [] =


### PR DESCRIPTION
Can't tell if this is being addressed in #63, apologies if so, but I noticed that using the Tab key to navigate between select components would leave multiple menu dropdowns open:
### Before
![2019-07-05 13 01 59](https://user-images.githubusercontent.com/26548438/60738216-8b3dbd00-9f2b-11e9-8d09-ae1db90a8ec4.gif)
### After
![2019-07-05 13 51 27](https://user-images.githubusercontent.com/26548438/60738374-2171e300-9f2c-11e9-925b-34dd44fa2e3f.gif)
