### PR TITLE
Separate FormBuilder props from component and render props

### DIFF
--- a/docs/Examples/Form.example.purs
+++ b/docs/Examples/Form.example.purs
@@ -50,9 +50,9 @@ docs = flip element {} $ unsafePerformEffect do
   component "FormExample" \_ -> React.do
     { formData, form } <- F.useForm metaForm
         { initialState: formDefaults
-        , readonly: false
         , inlineTable: false
         , forceTopLabels: false
+        , formProps: { readonly: false }
         }
 
     pure $ column_
@@ -109,10 +109,12 @@ mkUserFormExample = do
 
     { setModified, reset, validated, form } <- F.useForm userForm
         { initialState: formDefaults
-        , readonly: props.readonly
         , inlineTable: props.inlineTable
         , forceTopLabels: props.forceTopLabels && not props.inlineTable
-        , simulatePauses: props.simulatePauses
+        , formProps:
+            { readonly: props.readonly
+            , simulatePauses: props.simulatePauses
+            }
         }
 
     pure $ R.form -- Forms should be enclosed in a single "<form>" element to enable

--- a/src/Lumi/Components/Form.purs
+++ b/src/Lumi/Components/Form.purs
@@ -226,10 +226,7 @@ useForm
   :: forall props unvalidated result
    . Mapping ModifyValidated unvalidated unvalidated
   => FormBuilder
-       { initialState :: unvalidated
-       , readonly :: Boolean
-       , inlineTable :: Boolean
-       , forceTopLabels :: Boolean
+       { readonly :: Boolean
        | props
        }
        unvalidated
@@ -256,8 +253,21 @@ useForm editor props = Hooks.do
       , forceTopLabels: props.forceTopLabels
       }
 
-  f <- useForm' editor props
+  f <- useForm' editor (contractProps props)
   pure f { form = renderer f.form }
+  where
+    contractProps
+      :: { initialState :: unvalidated
+         , readonly :: Boolean
+         , inlineTable :: Boolean
+         , forceTopLabels :: Boolean
+         | props
+         }
+      -> { initialState :: unvalidated
+         , readonly :: Boolean
+         | props
+         }
+    contractProps = unsafeCoerce
 
 
 -- | Like `useForm`, but allows an alternative render implementation
@@ -265,13 +275,7 @@ useForm editor props = Hooks.do
 useForm'
   :: forall ui props unvalidated result
    . Mapping ModifyValidated unvalidated unvalidated
-  => FormBuilder'
-       ui
-       { initialState :: unvalidated
-       | props
-       }
-       unvalidated
-       result
+  => FormBuilder' ui { | props } unvalidated result
   -> { initialState :: unvalidated
      | props
      }
@@ -287,7 +291,7 @@ useForm' editor props = Hooks.do
   formData /\ setFormData <- Hooks.useState props.initialState
 
   let
-    { edit, validate: validated } = un FormBuilder editor props formData
+    { edit, validate: validated } = un FormBuilder editor (contractProps props) formData
     ui = edit setFormData
 
   pure
@@ -298,6 +302,9 @@ useForm' editor props = Hooks.do
     , validated
     , form: ui
     }
+  where
+    contractProps :: { initialState :: unvalidated | props } -> { | props }
+    contractProps = unsafeCoerce
 
 
 -- | Consume `useForm` as a render-prop component. Useful when `useForm`
@@ -310,15 +317,7 @@ formState
   :: forall props unvalidated result
    . Lacks "render" props
   => Mapping ModifyValidated unvalidated unvalidated
-  => FormBuilder
-       { initialState :: unvalidated
-       , readonly :: Boolean
-       , inlineTable :: Boolean
-       , forceTopLabels :: Boolean
-       | props
-       }
-       unvalidated
-       result
+  => FormBuilder { readonly :: Boolean | props } unvalidated result
   -> Hooks.ReactComponent
       { initialState :: unvalidated
       , readonly :: Boolean


### PR DESCRIPTION
This PR addresses the review comments in #39 and some concerns regarding the composability of form builders and different form rendering functions by moving form-specific props into a `formProps` key when effectively building forms into React components or hooks.

This PR also fixes the behavior of the success dialog in the Form example — prior to this, as soon as the form was validated the dialog would pop up.

**Note:** this is a _significantly large_ breaking change.