### PR TITLE
Replace em/rem with px

### DIFF
--- a/docs/App.jsx
+++ b/docs/App.jsx
@@ -28,7 +28,10 @@ import { attachGlobalComponentStyles } from "purs/Lumi.Components.Styles";
 attachGlobalComponentStyles();
 
 const repoSourceBasePath = `https://github.com/lumihq/purescript-lumi-components/blob/${COMMITHASH}`;
-const pursuitBasePath = `https://pursuit.purescript.org/packages/purescript-lumi-components/${VERSION.replace('v', '')}`;
+const pursuitBasePath = `https://pursuit.purescript.org/packages/purescript-lumi-components/${VERSION.replace(
+  "v",
+  ""
+)}`;
 
 const fromComponentPath = title => ({
   docs: Loadable({
@@ -194,7 +197,7 @@ const renderRoute = component => (
               className="lumi"
               target="_blank"
               href={component.apiReference}
-            style={{
+              style={{
                 marginLeft: "8px"
               }}
             >
@@ -250,7 +253,7 @@ const MenuLink = ({ toggleMenu }) =>
       onClick={toggleMenu}
       style={{
         color: cssStringHSLA(colors.black1),
-        marginRight: "1rem",
+        marginRight: "10px",
         display: "flex",
         justifyContent: "center",
         cursor: "pointer",
@@ -330,7 +333,7 @@ const SideNav = ({ children, isMobile, menuOpen }) => {
     borderRightStyle: "solid"
   };
   const navMobileInner = {
-    padding: "1em",
+    padding: "10px",
     height: "100%",
     overflowY: "auto",
     WebkitOverflowScrolling: "touch"
@@ -353,9 +356,9 @@ const NavSubtitle = ({ children }) =>
     ...sectionHeader,
     children: children,
     style: {
-      fontSize: "1.6em",
-      marginBottom: "1em",
-      marginTop: "1em"
+      fontSize: "16px",
+      marginBottom: "10px",
+      marginTop: "10px"
     }
   });
 
@@ -364,7 +367,7 @@ const ExampleArea = ({ children }) =>
     children: children,
     style: {
       width: "100%",
-      padding: "2em"
+      padding: "20px"
     }
   });
 
@@ -400,7 +403,7 @@ class ErrorBoundary extends Component {
             </pre>
           )
         ],
-        style: { padding: "1rem" }
+        style: { padding: "10px" }
       });
     }
     return this.props.children;

--- a/docs/Examples/Button.example.purs
+++ b/docs/Examples/Button.example.purs
@@ -119,4 +119,4 @@ docs =
 sections :: Array (Array JSX) -> Array JSX
 sections children = intercalate [ spacer ] children
   where
-    spacer = R.div { style: css { display: "flex", height: 1, paddingBottom: "2em" } }
+    spacer = R.div { style: css { display: "flex", height: 1, paddingBottom: "20px" } }

--- a/docs/Examples/Color.example.purs
+++ b/docs/Examples/Color.example.purs
@@ -1,7 +1,6 @@
 module Lumi.Components.Examples.Color where
 
 import Prelude
-
 import Color (cssStringHSLA)
 import Data.Foldable (intercalate)
 import Data.Maybe (Maybe(..))
@@ -24,19 +23,22 @@ docs =
     [ row
         { style: css { flexWrap: "wrap" }
         , children:
-            [ section
-                [ intercalate divider
-                    [ colorPanel _.black "Black" """default text color
+          [ section
+              [ intercalate divider
+                  [ colorPanel _.black "Black"
+                      """default text color
 active nav links
 active tabs
 active grid/lines icon on items page"""
-                    , colorPanel _.black1 "Black - 50%" """secondary text color
+                  , colorPanel _.black1 "Black - 50%"
+                      """secondary text color
 subtext
 inactive nav links
 inactive tabs
 column titles
 column sort arrow icon color"""
-                    , colorPanel _.black2 "Black - 30%" """text in disabled buttons and form fields
+                  , colorPanel _.black2 "Black - 30%"
+                      """text in disabled buttons and form fields
 icons in disabled buttons and form fields
 placeholder text in form fields
 toggle background
@@ -45,10 +47,12 @@ Checkbox border color (Hover state)
 Radio button border color (Hover state)
 Grey status pill text color
 inactive list/grid icon color"""
-                    , colorPanel _.black3 "Black - 18%" """Form field border (Regular/Inactive state)
+                  , colorPanel _.black3 "Black - 18%"
+                      """Form field border (Regular/Inactive state)
 Checkbox border color (Regular/Inactive state)
 Radio button border color (Regular/Inactive state)"""
-                    , colorPanel _.black4 "Black - 12%" """Table/list line colors
+                  , colorPanel _.black4 "Black - 12%"
+                      """Table/list line colors
 Divider line color
 Slat border color
 Container box color
@@ -56,67 +60,73 @@ Thumbnail border color
 Payment method border color
 Grey status pill border color
 Slider grey bar background color"""
-                    , colorPanel _.black5 "Black - 6%" """disabled input field background
+                  , colorPanel _.black5 "Black - 6%"
+                      """disabled input field background
 disabled checkbox background color
 disabled radio button background color
 disabled toggle background color"""
-                    , colorPanel _.black6 "Black - Background gray" """Nav bar background color
+                  , colorPanel _.black6 "Black - Background gray"
+                      """Nav bar background color
 Image background color"""
-                    , colorPanel _.black7 "Black - 4%" """dropdown hover background color"""
-                    , colorPanel _.black8 "Black - 2%" """table row hover background color"""
-                    ]
-                ]
-            , section
-                [ intercalate divider
-                    [ colorPanel _.primary "Primary" """primary actions
+                  , colorPanel _.black7 "Black - 4%" """dropdown hover background color"""
+                  , colorPanel _.black8 "Black - 2%" """table row hover background color"""
+                  ]
+              ]
+          , section
+              [ intercalate divider
+                  [ colorPanel _.primary "Primary"
+                      """primary actions
 active states
 links"""
-                    , colorPanel _.primary1 "Primary - 35%" """1px active border for input fields, radio buttons, and checkboxes"""
-                    , colorPanel _.primary2 "Primary - 25%" """Used for the disabled primary button background color"""
-                    , colorPanel _.primary3 "Primary - 15%" """tag color for multi select dropdowns, the 3px focus border for inputs, and the selected row background color in input dropdowns"""
-                    , colorPanel _.primary4 "Primary - 7%" """Input dropdown row hover background color
+                  , colorPanel _.primary1 "Primary - 35%" """1px active border for input fields, radio buttons, and checkboxes"""
+                  , colorPanel _.primary2 "Primary - 25%" """Used for the disabled primary button background color"""
+                  , colorPanel _.primary3 "Primary - 15%" """tag color for multi select dropdowns, the 3px focus border for inputs, and the selected row background color in input dropdowns"""
+                  , colorPanel _.primary4 "Primary - 7%"
+                      """Input dropdown row hover background color
 selected table row background color"""
-                    , colorPanel _.accent1 "Accent 1" """Indicates good or complete status"""
-                    , colorPanel _.accent2 "Accent 2" """Indicates pending, needs attention"""
-                    , colorPanel _.accent3 "Accent 3" """Indicates a problem, warning"""
-                    , colorPanel _.accent33 "Accent 3 - 15%" """Faded for focus borders/backgrounds"""
-                    , colorPanel _.white "White" """Primary button text"""
-                    ]
-                ]
-            ]
+                  , colorPanel _.accent1 "Accent 1" """Indicates good or complete status"""
+                  , colorPanel _.accent2 "Accent 2" """Indicates pending, needs attention"""
+                  , colorPanel _.accent3 "Accent 3" """Indicates a problem, warning"""
+                  , colorPanel _.accent33 "Accent 3 - 15%" """Faded for focus borders/backgrounds"""
+                  , colorPanel _.white "White" """Primary button text"""
+                  ]
+              ]
+          ]
         }
     ]
   where
-    colorPanel :: (forall a. ColorMap a -> a) -> String -> String -> JSX
-    colorPanel color title notes =
-      row_
-        [ column
-            { style: css { padding: "0.5rem", alignItems: "center", color: cssStringHSLA colors.black1 }
-            , children:
-                [ button defaults { size = Large, color = toNullable $ Just (color colorNames) }
-                , text body
-                    { children = [ R.text (unwrap <<< color $ colorNames) ]
-                    }
-                ]
-            }
-        , column
-            { style: css { padding: "0.5rem" }
-            , children:
-                [ body_ title ]
-                <> (
-                  split (Pattern "\n") notes <#> \note ->
-                    text subtext
-                      { style = css { color: cssStringHSLA colors.black1 }
-                      , children = [ R.text note ]
-                      }
+  colorPanel :: (forall a. ColorMap a -> a) -> String -> String -> JSX
+  colorPanel color title notes =
+    row_
+      [ column
+          { style: css { padding: "5px", alignItems: "center", color: cssStringHSLA colors.black1 }
+          , children:
+            [ button defaults { size = Large, color = toNullable $ Just (color colorNames) }
+            , text
+                body
+                  { children = [ R.text (unwrap <<< color $ colorNames) ]
+                  }
+            ]
+          }
+      , column
+          { style: css { padding: "5px" }
+          , children:
+            [ body_ title ]
+              <> ( split (Pattern "\n") notes
+                    <#> \note ->
+                        text
+                          subtext
+                            { style = css { color: cssStringHSLA colors.black1 }
+                            , children = [ R.text note ]
+                            }
                 )
-            }
-        ]
+          }
+      ]
 
-    section panels =
-      R.section
-        { style: css { maxWidth: "70rem", flex: "1 1 0" }
-        , children: panels
-        }
+  section panels =
+    R.section
+      { style: css { maxWidth: "700px", flex: "1 1 0" }
+      , children: panels
+      }
 
-    divider = row { style: css { height: "2rem" }, children: [] }
+  divider = row { style: css { height: "20px" }, children: [] }

--- a/docs/Examples/Form.example.purs
+++ b/docs/Examples/Form.example.purs
@@ -57,7 +57,7 @@ docs = flip element {} $ unsafePerformEffect do
 
     pure $ column_
       [ column
-          { style: css { width: "100%", maxWidth: 300, padding: "2rem 0" }
+          { style: css { width: "100%", maxWidth: 300, padding: "20px 0" }
           , children: [ form ]
           }
 

--- a/docs/Examples/LabeledField.example.purs
+++ b/docs/Examples/LabeledField.example.purs
@@ -55,9 +55,9 @@ docs =
     ]
   where
 
-    simpleDivider = divider { style: css { margin: "0.6rem 0", visibility: "hidden" } }
+    simpleDivider = divider { style: css { margin: "6px 0", visibility: "hidden" } }
 
-    inlineTableDivider = divider { style: css { margin: "0.6rem 0" } }
+    inlineTableDivider = divider { style: css { margin: "6px 0" } }
 
     makeLabeledFieldExamples forceTopLabel =
       [ labeledField defaults

--- a/docs/Examples/Layouts.example.purs
+++ b/docs/Examples/Layouts.example.purs
@@ -66,7 +66,7 @@ docs = (\c -> element c {}) $ withRouter $ toReactComponent identity component {
                   , content: \_ ->
                       R.div
                         { children: [ p_ "lorem ipsum"]
-                        , style: R.css { padding: "0.5em" }
+                        , style: R.css { padding: "5px" }
                         }
                   } :|
                   [ { id: TabId "shipment"
@@ -75,7 +75,7 @@ docs = (\c -> element c {}) $ withRouter $ toReactComponent identity component {
                     , content: \_ ->
                         R.div
                           { children: [ p_ "dolor sit amet"]
-                          , style: R.css { padding: "0.5em" }
+                          , style: R.css { padding: "5px" }
                           }
                     }
                   ]

--- a/docs/Examples/Progress.example.purs
+++ b/docs/Examples/Progress.example.purs
@@ -37,7 +37,7 @@ docs = unit # make component
   , render: \self ->
       column_
         [ column
-            { style: R.css { maxWidth: "50rem", padding: "2rem 0" }
+            { style: R.css { maxWidth: "500px", padding: "20px 0" }
             , children:
                 [ labeledField
                     { label: R.text "Adjust progress:"

--- a/docs/Examples/Select.example.purs
+++ b/docs/Examples/Select.example.purs
@@ -65,7 +65,7 @@ docs = unit # make component { initialState, render }
     render self@{ state: { disabled, example1, example2, example3, example4 } } =
       column_
         [ column
-            { style: css { maxWidth: "50rem", padding: "2rem 0" }
+            { style: css { maxWidth: 500, padding: "20px 0" }
             , children:
                 [ labeledField
                     { label: R.text "Disabled"

--- a/docs/Examples/Tooltip.example.purs
+++ b/docs/Examples/Tooltip.example.purs
@@ -57,7 +57,7 @@ docs =
               [ body_ "Hello, world see"
               , tooltip
                   { variant: "top"
-                  , style: R.css { padding: "0 0.2rem", textDecoration: "underline" }
+                  , style: R.css { padding: "0 2px", textDecoration: "underline" }
                   , text: "Lorem ipsum"
                   , content: body_ "here"
                   , size: toNullable Nothing
@@ -70,7 +70,7 @@ docs =
               [ body_ "Hello, world see"
               , tooltip
                   { variant: "top"
-                  , style: R.css { padding: "0 0.2rem", textDecoration: "underline" }
+                  , style: R.css { padding: "0 2px", textDecoration: "underline" }
                   , text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus."
                   , content: body_ "here"
                   , size: toNullable $ Just $ Large

--- a/docs/Examples/Upload.example.purs
+++ b/docs/Examples/Upload.example.purs
@@ -89,7 +89,7 @@ docs = unit # make component { initialState, didMount, render }
     render self =
       column_
         [ column
-            { style: R.css { maxWidth: "50rem", padding: "2rem 0" }
+            { style: R.css { maxWidth: 500, padding: "20px 0" }
             , children:
                 [ labeledField
                     { label: R.text "Readonly"

--- a/src/Lumi/Components/Button.purs
+++ b/src/Lumi/Components/Button.purs
@@ -196,7 +196,7 @@ styles = jss
               }
           , "&:focus":
               { outline: 0
-              , boxShadow: [ "0", "0", "0", "0.3rem", cssStringHSLA colors.primary3 ]
+              , boxShadow: [ "0", "0", "0", "3px", cssStringHSLA colors.primary3 ]
               }
           , "@media (min-width: 860px)":
               { padding: "6px 16px"

--- a/src/Lumi/Components/FixedPrecisionInput.purs
+++ b/src/Lumi/Components/FixedPrecisionInput.purs
@@ -110,7 +110,7 @@ fixedPrecisionInput = makeStateless component render
             [ css { "WebkitAppearance": "none"
                   , "MozAppearance": "none"
                   , margin: 0
-                  , width: "16rem"
+                  , width: 160
                   }
             , props.style
             ]

--- a/src/Lumi/Components/Form.purs
+++ b/src/Lumi/Components/Form.purs
@@ -1085,12 +1085,12 @@ styles = jss
   { "@global":
       { "lumi-form":
           { "& hr.lumi.field-divider":
-              { margin: "0.8rem 0"
+              { margin: "8px 0"
               , height: "0"
               , display: "none"
 
               , "@media (max-width: 860px)":
-                  { margin: "0.4rem 0"
+                  { margin: "4px 0"
                   }
               }
 
@@ -1132,7 +1132,7 @@ styles = jss
                   }
 
               , "& hr.lumi.field-divider":
-                  { height: "0.1rem"
+                  { height: "1px"
                   , display: "block"
                   }
 

--- a/src/Lumi/Components/Loader.purs
+++ b/src/Lumi/Components/Loader.purs
@@ -1,7 +1,6 @@
 module Lumi.Components.Loader where
 
 import Prelude
-
 import Color (cssStringHSLA)
 import Data.Nullable (Nullable)
 import JSS (JSS, jss)
@@ -9,10 +8,10 @@ import Lumi.Components.Color (colors)
 import React.Basic (Component, JSX, createComponent, element, makeStateless)
 import React.Basic.DOM (CSS, unsafeCreateDOMComponent)
 
-type LoaderProps =
-  { style :: CSS
-  , testId :: Nullable String
-  }
+type LoaderProps
+  = { style :: CSS
+    , testId :: Nullable String
+    }
 
 component :: Component LoaderProps
 component = createComponent "Loader"
@@ -20,33 +19,36 @@ component = createComponent "Loader"
 loader :: LoaderProps -> JSX
 loader = makeStateless component $ loaderElement <<< mapProps
   where
-    loaderElement = element (unsafeCreateDOMComponent "lumi-loader")
-    mapProps props =
-      { style: props.style
-      , "data-testid": props.testId
-      }
+  loaderElement = element (unsafeCreateDOMComponent "lumi-loader")
+
+  mapProps props =
+    { style: props.style
+    , "data-testid": props.testId
+    }
 
 styles :: JSS
-styles = jss
-  { "@global":
-      { "lumi-loader": spinnerMixin { radius: "3.8rem", borderWidth: "0.5rem" }
+styles =
+  jss
+    { "@global":
+      { "lumi-loader": spinnerMixin { radius: "38px", borderWidth: "5px" }
       , "@keyframes spin":
-          { from: { transform: "rotate(0deg)" }
-          , to: { transform: "rotate(360deg)" }
-          }
+        { from: { transform: "rotate(0deg)" }
+        , to: { transform: "rotate(360deg)" }
+        }
       }
-  }
+    }
 
 spinnerMixin :: { radius :: String, borderWidth :: String } -> JSS
-spinnerMixin { radius, borderWidth } = jss
-  { boxSizing: "border-box"
-  , content: "\"\""
-  , display: "inline-block"
-  , height: radius
-  , width: radius
-  , border: [ borderWidth, "solid", cssStringHSLA colors.black1 ]
-  , borderTopColor: cssStringHSLA colors.black4
-  , borderRadius: "50%"
-  , animation: "spin 1s infinite linear"
-  , animationName: "spin"
-  }
+spinnerMixin { radius, borderWidth } =
+  jss
+    { boxSizing: "border-box"
+    , content: "\"\""
+    , display: "inline-block"
+    , height: radius
+    , width: radius
+    , border: [ borderWidth, "solid", cssStringHSLA colors.black1 ]
+    , borderTopColor: cssStringHSLA colors.black4
+    , borderRadius: "50%"
+    , animation: "spin 1s infinite linear"
+    , animationName: "spin"
+    }

--- a/src/Lumi/Components/Modal.purs
+++ b/src/Lumi/Components/Modal.purs
@@ -281,7 +281,7 @@ modalPortal = toReactComponent identity modalPortalComponent
                                           { title = props.actionButtonTitle
                                           , buttonState = props.actionButtonState
                                           , onPress = mkEffectFn1 \_ -> actionFn
-                                          , style = R.css { marginLeft: "1.2rem" }
+                                          , style = R.css { marginLeft: "12px" }
                                           }
                                     ]
                                 }
@@ -327,7 +327,7 @@ styles = jss
               { boxSizing: "border-box"
               , display: "flex"
               , flexFlow: "column"
-              , padding: "6.4rem 0"
+              , padding: "64px 0"
               , "@media (max-width: 860px)": { padding: "0" }
               , flex: "0 0 auto" -- expand to encompass large modals with scrolling
               , minHeight: "100%" -- vertical centering of small modals
@@ -339,37 +339,37 @@ styles = jss
                   , display: "flex"
                   , flexFlow: "column"
                   , position: "relative"
-                  , padding: "2.4rem 0"
+                  , padding: "24px 0"
                   , "&[data-size=\"small\"]":
-                      { width: "40rem"
+                      { width: "400px"
                       }
                   , "&[data-size=\"medium\"]":
-                      { width: "50.4rem"
+                      { width: "504px"
                       }
                   , "&[data-size=\"large\"]":
-                      { width: "60rem"
+                      { width: "600px"
                       }
                   , "&[data-size=\"extra-large\"]":
-                      { width: "84.8rem"
+                      { width: "848px"
                       }
-                  , maxWidth: "calc(100vw - (2.4rem * 2))"
+                  , maxWidth: "calc(100vw - (24px * 2))"
                   , background: "rgba(255, 255, 255, 1)"
-                  , borderRadius: "0.4rem"
+                  , borderRadius: "4px"
 
                   , "& lumi-modal-close":
                       { boxSizing: "border-box"
                       , position: "absolute"
-                      , top: "2.2rem"
-                      , right: "2.4rem"
+                      , top: "22px"
+                      , right: "24px"
                       , display: "flex"
                       , flexFlow: "column"
-                      , fontSize: "1.4rem"
+                      , fontSize: "14px"
                       , color: cssStringHSLA colors.black2
                       , cursor: "pointer"
                       , "@media (max-width: 860px)":
                           { "& lumi-font-icon":
-                              { fontSize: "1.6rem"
-                              , lineHeight: "2.4rem"
+                              { fontSize: "16px"
+                              , lineHeight: "24px"
                               }
                           }
                       }
@@ -378,12 +378,12 @@ styles = jss
                       , flex: "0 0 auto"
                       , display: "flex"
                       , flexFlow: "column"
-                      , paddingLeft: "2.4rem"
-                      , paddingRight: "4.8rem" -- avoid colliding with the close "X"
+                      , paddingLeft: "24px"
+                      , paddingRight: "48px" -- avoid colliding with the close "X"
                       , "@media (max-width: 860px)":
-                          { paddingLeft: "1.6rem"
+                          { paddingLeft: "16px"
                           }
-                      , padding: "0 4.8rem 0 2.4rem"
+                      , padding: "0 48px 0 24px"
                       , "& > lumi-section-header":
                           { paddingTop: "0"
                           , marginTop: "0"
@@ -392,21 +392,21 @@ styles = jss
                       }
                   , "& lumi-modal-content":
                       { boxSizing: "border-box"
-                      , margin: "2.4rem 0"
+                      , margin: "24px 0"
                       , flex: "1 0 auto"
                       , display: "flex"
                       , flexFlow: "column"
-                      , paddingLeft: "2.4rem"
-                      , paddingRight: "2.4rem"
+                      , paddingLeft: "24px"
+                      , paddingRight: "24px"
                       , "@media (max-width: 860px)":
-                          { paddingLeft: "1.6rem"
-                          , paddingRight: "1.6rem"
+                          { paddingLeft: "16px"
+                          , paddingRight: "16px"
                           }
                       , "&[data-internal-borders=\"true\"]":
-                          { borderTop: [ "0.1rem", "solid", cssStringHSLA colors.black4 ]
-                          , borderBottom: [ "0.1rem", "solid", cssStringHSLA colors.black4 ]
-                          , paddingTop: "0.8rem"
-                          , paddingBottom: "0.8rem"
+                          { borderTop: [ "1px", "solid", cssStringHSLA colors.black4 ]
+                          , borderBottom: [ "1px", "solid", cssStringHSLA colors.black4 ]
+                          , paddingTop: "8px"
+                          , paddingBottom: "8px"
                           }
                       }
                   , "& lumi-modal-footer":
@@ -415,15 +415,15 @@ styles = jss
                       , display: "flex"
                       , flexFlow: "row"
                       , justifyContent: "flex-end"
-                      , paddingLeft: "2.4rem"
-                      , paddingRight: "2.4rem"
+                      , paddingLeft: "24px"
+                      , paddingRight: "24px"
                       , "@media (max-width: 860px)":
-                          { paddingLeft: "1.6rem"
-                          , paddingRight: "1.6rem"
+                          { paddingLeft: "16px"
+                          , paddingRight: "16px"
                           , "& button.lumi":
-                              { fontSize: "1.6rem"
-                              , lineHeight: "2.4rem"
-                              , padding: "1rem 2.1rem 1rem"
+                              { fontSize: "16px"
+                              , lineHeight: "24px"
+                              , padding: "10px 21px 10px"
                               }
                           }
                       }
@@ -444,7 +444,7 @@ styles = jss
                   }
 
               , "&[data-variant=\"dialog\"] lumi-modal lumi-modal-content":
-                  { margin: "0 0 1.6rem"
+                  { margin: "0 0 16px"
                   }
 
                 -- constrain total height while making the intenal content area flexible and scrollable

--- a/src/Lumi/Components/NativeSelect.purs
+++ b/src/Lumi/Components/NativeSelect.purs
@@ -76,12 +76,12 @@ styles :: JSS
 styles = jss
   { "@global":
       { "select.lumi":
-          { fontSize: "1.4rem"
-          , height: "3.2rem"
-          , lineHeight: "3.2rem"
+          { fontSize: "14px"
+          , height: "32px"
+          , lineHeight: "32px"
           , "@media (max-width: 860px)":
-              { height: "4rem"
-              , lineHeight: "4rem"
+              { height: "40px"
+              , lineHeight: "40px"
               }
           , appearance: "none"
           , backgroundImage: "url(\"data:image/svg+xml;charset=utf8,%3C?xml version='1.0' encoding='UTF-8'?%3E%3Csvg width='11px' height='5px' viewBox='0 0 11 5' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3C!-- Generator: Sketch 49.1 (51147) - http://www.bohemiancoding.com/sketch --%3E%3Ctitle%3ESlice 1%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cdefs%3E%3Cpath d='M5.417,3.519 C5.797,3.187 6.307,2.733 6.912,2.185 L6.974,2.129 C7.70584693,1.46645784 8.43485361,0.800785071 9.161,0.132 C9.29247374,0.0108869595 9.47857352,-0.0308857001 9.64919735,0.0224173781 C9.81982119,0.0757204563 9.94904726,0.216001266 9.98819736,0.390417384 C10.0273475,0.564833501 9.97047374,0.746886966 9.839,0.868 C9.11068658,1.53896706 8.37934578,2.20664054 7.645,2.871 L7.583,2.927 C5.376,4.922 5.287,5 5,5 C4.713,5 4.624,4.922 2.417,2.927 L2.355,2.871 C1.62081041,2.20646869 0.889470368,1.5387959 0.161,0.868 C-0.0422407879,0.68077547 -0.0552245302,0.364240788 0.132,0.161 C0.31922453,-0.0422407879 0.635759212,-0.0552245302 0.839,0.132 C1.5649901,0.800955473 2.29399753,1.46662893 3.026,2.129 L3.088,2.185 C3.693,2.733 4.203,3.187 4.583,3.519 C4.75,3.665 4.89,3.785 5,3.877 C5.11,3.785 5.25,3.665 5.417,3.519 Z' id='path-1'%3E%3C/path%3E%3C/defs%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='arrow-down'%3E%3Cg id='a-link' fill='%2342413F' fill-rule='nonzero'%3E%3Cpath d='M5.417,3.519 C5.797,3.187 6.307,2.733 6.912,2.185 L6.974,2.129 C7.70584693,1.46645784 8.43485361,0.800785071 9.161,0.132 C9.29247374,0.0108869595 9.47857352,-0.0308857001 9.64919735,0.0224173781 C9.81982119,0.0757204563 9.94904726,0.216001266 9.98819736,0.390417384 C10.0273475,0.564833501 9.97047374,0.746886966 9.839,0.868 C9.11068658,1.53896706 8.37934578,2.20664054 7.645,2.871 L7.583,2.927 C5.376,4.922 5.287,5 5,5 C4.713,5 4.624,4.922 2.417,2.927 L2.355,2.871 C1.62081041,2.20646869 0.889470368,1.5387959 0.161,0.868 C-0.0422407879,0.68077547 -0.0552245302,0.364240788 0.132,0.161 C0.31922453,-0.0422407879 0.635759212,-0.0552245302 0.839,0.132 C1.5649901,0.800955473 2.29399753,1.46662893 3.026,2.129 L3.088,2.185 C3.693,2.733 4.203,3.187 4.583,3.519 C4.75,3.665 4.89,3.785 5,3.877 C5.11,3.785 5.25,3.665 5.417,3.519 Z' id='a'%3E%3C/path%3E%3C/g%3E%3Cg id='Clipped'%3E%3Cmask id='mask-2' fill='white'%3E%3Cuse xlink:href='%23path-1'%3E%3C/use%3E%3C/mask%3E%3Cg id='a'%3E%3C/g%3E%3Cg id='Group' mask='url(%23mask-2)' fill='%23292827' fill-rule='nonzero'%3E%3Cg transform='translate(-5.000000, -8.000000)' id='Shape'%3E%3Cpolygon points='0 0 20 0 20 20 0 20'%3E%3C/polygon%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E\")"
@@ -100,8 +100,8 @@ styles = jss
               { fontWeight: "normal"
               , display: "block"
               , whiteSpace: "pre"
-              , minHeight: "1.2em"
-              , padding: "0 0.2rem 0.1rem"
+              , minHeight: "12px"
+              , padding: "0 2px 1px"
               , "&:hover, &:active":
                   { backgroundColor: [ cssStringHSLA colors.primary, "!important" ]
                   }

--- a/src/Lumi/Components/StatusSlat.purs
+++ b/src/Lumi/Components/StatusSlat.purs
@@ -68,9 +68,9 @@ styles = jss
           , "& lumi-status-slat-cell":
               { borderRight: [ "1px", "solid", cssStringHSLA colors.black4 ]
               , height: "100%"
-              , minWidth: "calc(25% - (2 * 1.6rem))"
+              , minWidth: "calc(25% - (2 * 16px))"
               , display: "inline-block"
-              , padding: "0 1.6rem"
+              , padding: "0 16px"
               , whiteSpace: "nowrap"
               , overflow: "hidden"
               , textOverflow: "ellipsis"

--- a/src/Lumi/Components/Table.purs
+++ b/src/Lumi/Components/Table.purs
@@ -338,7 +338,7 @@ table = make component
             if not self.props.selectable
               then empty
               else R.th
-                { style: R.css { width: "2rem" }
+                { style: R.css { width: "20px" }
                 , onClick: Events.handler (stopPropagation) (const (pure unit))
                 , children:
                     [ input checkbox
@@ -392,12 +392,12 @@ table = make component
                               , onClick: Events.handler_ (runEffectFn2 self.props.updateSort flippedSort col.sortBy)
                               , children:
                                   [ R.span
-                                      { style: R.css { marginRight: "0.5rem" }
+                                      { style: R.css { marginRight: "5px" }
                                       , children: [ subtext_ label ]
                                       }
                                   , R.span
                                       { style: R.css
-                                          { fontSize: "1rem"
+                                          { fontSize: "10px"
                                             , visibility:
                                                 if sortBy == Just colSortBy
                                                   then "visible"
@@ -537,7 +537,7 @@ tableRow = make tableRowComponent { initialState: unit, shouldUpdate, render }
     renderBodyRowCheckbox { checked, onChange } =
       R.td
         { key: "_checkbox"
-        , style: R.css { width: "2rem" }
+        , style: R.css { width: "20px" }
         , onClick: Events.handler stopPropagation (const (pure unit))
         , children:
             [ input checkbox
@@ -748,7 +748,7 @@ styles = jss
           , borderRadius: "3px"
           , display: "flex"
           , flexFlow: "column nowrap"
-          , fontSize: "1rem"
+          , fontSize: "10px"
           , maxWidth: "300px"
           , minWidth: "200px"
           }

--- a/src/Lumi/Components/Table/FilterDropdown.purs
+++ b/src/Lumi/Components/Table/FilterDropdown.purs
@@ -107,16 +107,16 @@ filterItem_ = makeStateless filterItemComponent render
                     element (unsafeCreateDOMComponent "lumi-row")
                       { className: if item.hidden then "" else "active"
                       , style: css
-                          { padding: "0 0.8rem 0 0"
+                          { padding: "0 8px 0 0"
                           , alignItems: "center"
                           , borderTop:
                               if isOver && (fromMaybe false ((\dragItem -> dragItem.index > index) <$> maybeDragItem))
-                              then "0.2rem solid #0044e4"
-                              else "0.2rem solid transparent"
+                              then "2px solid #0044e4"
+                              else "2px solid transparent"
                           , borderBottom:
                               if isOver && (fromMaybe false ((\dragItem -> dragItem.index < index) <$> maybeDragItem))
-                              then "0.2rem solid #0044e4"
-                              else "0.2rem solid transparent"
+                              then "2px solid #0044e4"
+                              else "2px solid transparent"
                           , opacity: if isDragging then 0.1 else 1.0
                           }
                       , children:
@@ -152,9 +152,9 @@ filterItem_ = makeStateless filterItemComponent render
     renderLabel item =
       div
         { style: css
-            { paddingLeft: "0.8rem"
-            , paddingRight: "0.8rem"
-            , fontSize: "1.2rem"
+            { paddingLeft: "8px"
+            , paddingRight: "8px"
+            , fontSize: "12px"
             , flex: 1
             , whiteSpace: "nowrap"
             , overflow: "hidden"

--- a/src/Lumi/Components/Text.purs
+++ b/src/Lumi/Components/Text.purs
@@ -1,7 +1,6 @@
 module Lumi.Components.Text where
 
 import Prelude
-
 import Color (cssStringHSLA)
 import Data.Array (foldMap)
 import Data.Maybe (Maybe(..))
@@ -13,14 +12,14 @@ import React.Basic (Component, JSX, createComponent, element, makeStateless)
 import React.Basic.DOM (CSS, css, unsafeCreateDOMComponent)
 import React.Basic.DOM as R
 
-type TextProps =
-  { children :: Array JSX
-  , className :: Nullable String
-  , color :: Nullable ColorName
-  , style :: CSS
-  , tag :: String
-  , testId :: Nullable String
-  }
+type TextProps
+  = { children :: Array JSX
+    , className :: Nullable String
+    , color :: Nullable ColorName
+    , style :: CSS
+    , tag :: String
+    , testId :: Nullable String
+    }
 
 component :: Component TextProps
 component = createComponent "Text"
@@ -28,27 +27,25 @@ component = createComponent "Text"
 text :: TextProps -> JSX
 text = makeStateless component render
   where
-    render { children, className, color, style, tag, testId } =
-      case indexOf (Pattern "lumi-") tag of
-        Just 0 ->
-          element (unsafeCreateDOMComponent tag)
-            { children
-            , "class": className
-            , "data-color": color
-            , "data-testid": testId
-            , style
-            }
-        _      ->
-          element (unsafeCreateDOMComponent tag)
-            { children
-            , className: "lumi" <> foldMap (" " <> _) (toMaybe className)
-            , "data-color": color
-            , "data-testid": testId
-            , style
-            }
+  render { children, className, color, style, tag, testId } = case indexOf (Pattern "lumi-") tag of
+    Just 0 ->
+      element (unsafeCreateDOMComponent tag)
+        { children
+        , "class": className
+        , "data-color": color
+        , "data-testid": testId
+        , style
+        }
+    _ ->
+      element (unsafeCreateDOMComponent tag)
+        { children
+        , className: "lumi" <> foldMap (" " <> _) (toMaybe className)
+        , "data-color": color
+        , "data-testid": testId
+        , style
+        }
 
 -- Lumi-styled defaults for built in elements with padding
-
 h1 :: TextProps
 h1 = body { tag = "h1" }
 
@@ -98,7 +95,6 @@ span_ :: String -> JSX
 span_ str = text span { children = [ R.text str ] }
 
 -- Lumi-specific elements with no padding
-
 mainHeader :: TextProps
 mainHeader = body { tag = "lumi-main-header" }
 
@@ -152,123 +148,106 @@ nbsp :: String
 nbsp = " "
 
 styles :: JSS
-styles = jss
-  { "@global":
+styles =
+  jss
+    { "@global":
       { "lumi-main-header": lumiMainHeader
-
       , "lumi-title": lumiTitle
-
       , "lumi-section-header": lumiSectionHeader
-
       , "lumi-subsection-header": lumiSubsectionHeader
-
       , "body.lumi, lumi-body": lumiBody
-
       , "lumi-paragraph": lumiParagraph
-
       , "lumi-subtext": lumiSubtext
-
       , "h1, h2, h3, h4, h5, h6":
-          { "&.lumi": { paddingBottom: "1rem" }
-          }
-
+        { "&.lumi": { paddingBottom: "10px" }
+        }
       , "h1.lumi": lumiMainHeader
-
       , "h2.lumi": lumiTitle
-
       , "h3.lumi":
-          { extend: lumiSectionHeader
-          , marginTop: "initial"
-          }
-
+        { extend: lumiSectionHeader
+        , marginTop: "initial"
+        }
       , "h4.lumi": lumiSubsectionHeader
-
       , "h5.lumi": lumiSubsectionHeader
-
       , "h6.lumi": lumiSubsectionHeader
-
       , "p.lumi":
-          { extend: lumiBody
-          , wordWrap: "break-word"
-          , padding: "0.5em 0"
-          }
-
+        { extend: lumiBody
+        , wordWrap: "break-word"
+        , padding: "5px 0"
+        }
       , "caption": lumiSubtext
-
-      , "section.lumi": { padding: "2em" }
-
+      , "section.lumi": { padding: "20px" }
       , "strong.lumi": { fontWeight: "600" }
-
       , "lumi-main-header, lumi-title, lumi-section-header, lumi-subsection-header, lumi-body, lumi-subtext, body.lumi, h1.lumi, h2.lumi, h3.lumi, h4.lumi, h5.lumi, h6.lumi, caption.lumi, section.lumi, strong.lumi":
-          { "&[data-color=\"black\"]": { color: cssStringHSLA colors.black }
-          , "&[data-color=\"black-1\"]": { color: cssStringHSLA colors.black1 }
-          , "&[data-color=\"black-2\"]": { color: cssStringHSLA colors.black2 }
-          , "&[data-color=\"black-3\"]": { color: cssStringHSLA colors.black3 }
-          , "&[data-color=\"black-4\"]": { color: cssStringHSLA colors.black4 }
-          , "&[data-color=\"black-5\"]": { color: cssStringHSLA colors.black5 }
-          , "&[data-color=\"black-6\"]": { color: cssStringHSLA colors.black6 }
-          , "&[data-color=\"black-7\"]": { color: cssStringHSLA colors.black7 }
-          , "&[data-color=\"black-8\"]": { color: cssStringHSLA colors.black8 }
-          , "&[data-color=\"primary\"]": { color: cssStringHSLA colors.primary }
-          , "&[data-color=\"primary-1\"]": { color: cssStringHSLA colors.primary1 }
-          , "&[data-color=\"primary-2\"]": { color: cssStringHSLA colors.primary2 }
-          , "&[data-color=\"primary-3\"]": { color: cssStringHSLA colors.primary3 }
-          , "&[data-color=\"primary-4\"]": { color: cssStringHSLA colors.primary4 }
-          , "&[data-color=\"accent-1\"]": { color: cssStringHSLA colors.accent1 }
-          , "&[data-color=\"accent-2\"]": { color: cssStringHSLA colors.accent2 }
-          , "&[data-color=\"accent-3\"]": { color: cssStringHSLA colors.accent3 }
-          , "&[data-color=\"accent-3-3\"]": { color: cssStringHSLA colors.accent33 }
-          , "&[data-color=\"white\"]": { color: cssStringHSLA colors.white }
-          , "&[data-color=\"secondary\"]": { color: cssStringHSLA colors.black1 }
-          , "&[data-color=\"finished\"]": { color: cssStringHSLA colors.primary }
-          , "&[data-color=\"active\"]": { color: cssStringHSLA colors.accent1 }
-          , "&[data-color=\"warning\"]": { color: cssStringHSLA colors.accent2 }
-          , "&[data-color=\"error\"]": { color: cssStringHSLA colors.accent3 }
-          }
+        { "&[data-color=\"black\"]": { color: cssStringHSLA colors.black }
+        , "&[data-color=\"black-1\"]": { color: cssStringHSLA colors.black1 }
+        , "&[data-color=\"black-2\"]": { color: cssStringHSLA colors.black2 }
+        , "&[data-color=\"black-3\"]": { color: cssStringHSLA colors.black3 }
+        , "&[data-color=\"black-4\"]": { color: cssStringHSLA colors.black4 }
+        , "&[data-color=\"black-5\"]": { color: cssStringHSLA colors.black5 }
+        , "&[data-color=\"black-6\"]": { color: cssStringHSLA colors.black6 }
+        , "&[data-color=\"black-7\"]": { color: cssStringHSLA colors.black7 }
+        , "&[data-color=\"black-8\"]": { color: cssStringHSLA colors.black8 }
+        , "&[data-color=\"primary\"]": { color: cssStringHSLA colors.primary }
+        , "&[data-color=\"primary-1\"]": { color: cssStringHSLA colors.primary1 }
+        , "&[data-color=\"primary-2\"]": { color: cssStringHSLA colors.primary2 }
+        , "&[data-color=\"primary-3\"]": { color: cssStringHSLA colors.primary3 }
+        , "&[data-color=\"primary-4\"]": { color: cssStringHSLA colors.primary4 }
+        , "&[data-color=\"accent-1\"]": { color: cssStringHSLA colors.accent1 }
+        , "&[data-color=\"accent-2\"]": { color: cssStringHSLA colors.accent2 }
+        , "&[data-color=\"accent-3\"]": { color: cssStringHSLA colors.accent3 }
+        , "&[data-color=\"accent-3-3\"]": { color: cssStringHSLA colors.accent33 }
+        , "&[data-color=\"white\"]": { color: cssStringHSLA colors.white }
+        , "&[data-color=\"secondary\"]": { color: cssStringHSLA colors.black1 }
+        , "&[data-color=\"finished\"]": { color: cssStringHSLA colors.primary }
+        , "&[data-color=\"active\"]": { color: cssStringHSLA colors.accent1 }
+        , "&[data-color=\"warning\"]": { color: cssStringHSLA colors.accent2 }
+        , "&[data-color=\"error\"]": { color: cssStringHSLA colors.accent3 }
+        }
       }
-  }
+    }
   where
-    lumiMainHeader =
-      { fontSize: "25px"
-      , lineHeight: "40px"
-      , fontWeight: "600"
-      }
+  lumiMainHeader =
+    { fontSize: "25px"
+    , lineHeight: "40px"
+    , fontWeight: "600"
+    }
 
-    lumiTitle =
-      { fontSize: "20px"
-      , lineHeight: "32px"
-      , fontWeight: "400"
-      }
+  lumiTitle =
+    { fontSize: "20px"
+    , lineHeight: "32px"
+    , fontWeight: "400"
+    }
 
-    lumiSectionHeader =
-      { fontSize: "17px"
-      , lineHeight: "24px"
-      , fontWeight: "600"
-      , display: "inline-block"
-      }
+  lumiSectionHeader =
+    { fontSize: "17px"
+    , lineHeight: "24px"
+    , fontWeight: "600"
+    , display: "inline-block"
+    }
 
-    lumiSubsectionHeader =
-      { fontSize: lumiSubsectionHeaderFontSize
-      , lineHeight: "24px"
-      , fontWeight: "600"
-      }
+  lumiSubsectionHeader =
+    { fontSize: lumiSubsectionHeaderFontSize
+    , lineHeight: "24px"
+    , fontWeight: "600"
+    }
 
-    lumiBody =
-      { fontSize: "14px"
-      , lineHeight: "20px"
-      , fontWeight: "400"
-      }
+  lumiBody =
+    { fontSize: "14px"
+    , lineHeight: "20px"
+    , fontWeight: "400"
+    }
 
-    lumiParagraph =
-      { fontSize: "14px"
-      , lineHeight: "24px"
-      }
+  lumiParagraph =
+    { fontSize: "14px"
+    , lineHeight: "24px"
+    }
 
-    lumiSubtext =
-      { fontSize: lumiSubtextFontSize
-      , lineHeight: "16px"
-      , fontWeight: "400"
-      }
+  lumiSubtext =
+    { fontSize: lumiSubtextFontSize
+    , lineHeight: "16px"
+    , fontWeight: "400"
+    }
 
 lumiSubsectionHeaderFontSize :: String
 lumiSubsectionHeaderFontSize = "15px"

--- a/src/Lumi/Components/Textarea.purs
+++ b/src/Lumi/Components/Textarea.purs
@@ -1,7 +1,6 @@
 module Lumi.Components.Textarea where
 
 import Prelude
-
 import Data.Maybe (Maybe(..))
 import Data.Nullable (Nullable, toNullable)
 import Effect.Uncurried (mkEffectFn1)
@@ -11,24 +10,24 @@ import React.Basic (Component, JSX, createComponent, element, makeStateless)
 import React.Basic.DOM (CSS, css, unsafeCreateDOMComponent)
 import React.Basic.Events (EventHandler)
 
-type TextareaProps =
-  { autoComplete :: String
-  , disabled :: Boolean
-  , lines :: Int
-  , maxLength :: Nullable Number
-  , minLength :: Nullable Number
-  , name :: String
-  , onBlur :: Nullable EventHandler
-  , onChange :: EventHandler
-  , onFocus :: Nullable EventHandler
-  , placeholder :: String
-  , readOnly :: Boolean
-  , required :: Boolean
-  , resizable :: Boolean
-  , style :: CSS
-  , testId :: Nullable String
-  , value :: String
-  }
+type TextareaProps
+  = { autoComplete :: String
+    , disabled :: Boolean
+    , lines :: Int
+    , maxLength :: Nullable Number
+    , minLength :: Nullable Number
+    , name :: String
+    , onBlur :: Nullable EventHandler
+    , onChange :: EventHandler
+    , onFocus :: Nullable EventHandler
+    , placeholder :: String
+    , readOnly :: Boolean
+    , required :: Boolean
+    , resizable :: Boolean
+    , style :: CSS
+    , testId :: Nullable String
+    , value :: String
+    }
 
 component :: Component TextareaProps
 component = createComponent "Textarea"
@@ -36,26 +35,26 @@ component = createComponent "Textarea"
 textarea :: TextareaProps -> JSX
 textarea = makeStateless component render
   where
-    render props =
-      element (unsafeCreateDOMComponent "textarea")
-        { "data-testid": props.testId
-        , "data-disable-resize": not props.resizable
-        , autoComplete: props.autoComplete
-        , className: "lumi"
-        , disabled: props.disabled
-        , maxLength: props.maxLength
-        , minLength: props.minLength
-        , name: props.name
-        , onBlur: props.onBlur
-        , onChange: props.onChange
-        , onFocus: props.onFocus
-        , placeholder: props.placeholder
-        , required: props.required
-        , readOnly: props.readOnly
-        , rows: props.lines
-        , style: props.style
-        , value: props.value
-        }
+  render props =
+    element (unsafeCreateDOMComponent "textarea")
+      { "data-testid": props.testId
+      , "data-disable-resize": not props.resizable
+      , autoComplete: props.autoComplete
+      , className: "lumi"
+      , disabled: props.disabled
+      , maxLength: props.maxLength
+      , minLength: props.minLength
+      , name: props.name
+      , onBlur: props.onBlur
+      , onChange: props.onChange
+      , onFocus: props.onFocus
+      , placeholder: props.placeholder
+      , required: props.required
+      , readOnly: props.readOnly
+      , rows: props.lines
+      , style: props.style
+      , value: props.value
+      }
 
 defaults :: TextareaProps
 defaults =
@@ -78,32 +77,30 @@ defaults =
   }
 
 styles :: JSS
-styles = jss
-  { "@global":
+styles =
+  jss
+    { "@global":
       { "textarea.lumi":
-          { fontFamily: "inherit"
-          , fontSize: "1.4rem"
-          , lineHeight: "2rem"
-          , touchAction: "manipulation"
-          , boxSizing: "border-box"
-          , resize: "vertical"
-          , minHeight: "32px"
-
-          , extend: lumiInputStyles
-          , "&:hover": lumiInputHoverStyles
-          , "&:invalid": lumiInputInvalidStyles
-          , "&:focus":
-              { extend: lumiInputFocusStyles
-              , "&:invalid": lumiInputFocusInvalidStyles
-              }
-          , "&:disabled": lumiInputDisabledStyles
-
-          , "&::-webkit-input-placeholder": lumiInputPlaceholderStyles
-          , "&::-moz-placeholder": lumiInputPlaceholderStyles
-          , "&:-ms-input-placeholder": lumiInputPlaceholderStyles
-          , "&::placeholder": lumiInputPlaceholderStyles
-
-          , "&[data-disable-resize=\"true\"]": { resize: "none" }
+        { fontFamily: "inherit"
+        , fontSize: "14px"
+        , lineHeight: "20px"
+        , touchAction: "manipulation"
+        , boxSizing: "border-box"
+        , resize: "vertical"
+        , minHeight: "32px"
+        , extend: lumiInputStyles
+        , "&:hover": lumiInputHoverStyles
+        , "&:invalid": lumiInputInvalidStyles
+        , "&:focus":
+          { extend: lumiInputFocusStyles
+          , "&:invalid": lumiInputFocusInvalidStyles
           }
+        , "&:disabled": lumiInputDisabledStyles
+        , "&::-webkit-input-placeholder": lumiInputPlaceholderStyles
+        , "&::-moz-placeholder": lumiInputPlaceholderStyles
+        , "&:-ms-input-placeholder": lumiInputPlaceholderStyles
+        , "&::placeholder": lumiInputPlaceholderStyles
+        , "&[data-disable-resize=\"true\"]": { resize: "none" }
+        }
       }
-  }
+    }


### PR DESCRIPTION
We currently use a mix of em/rem and px values. This results in some parts of components scaling differently than others when used in contexts with different font sizes. Until we decide on a particular pattern (I'd like to explore more general theming) px values seem to make the most sense, as it ensures the resulting components will always look the same as they do on the demo pages.