### PR TITLE
Explicitly set input height where possible to reduce browser inconsistencies

### DIFF
--- a/src/Lumi/Components/Input.purs
+++ b/src/Lumi/Components/Input.purs
@@ -667,9 +667,12 @@ lumiInputStyles = jss
   , color: cssStringHSLA colors.black
   , fontSize: "14px"
   , lineHeight: "20px"
+  , fontFamily: "inherit"
+  , height: "40px"
   , padding: [ inputPaddingYMobile, "10px" ]
   , "@media (min-width: 860px)":
-      { padding: [ inputPaddingYDesktop, "10px" ]
+      { height: "32px"
+      , padding: [ inputPaddingYDesktop, "10px" ]
       }
   , outline: "none"
   , touchAction: "manipulation"

--- a/src/Lumi/Components/Select.purs
+++ b/src/Lumi/Components/Select.purs
@@ -484,7 +484,11 @@ styles = jss
               }
 
           , "&[data-multi=\"true\"]":
-              { "& lumi-select-input-selected-value":
+              { "& lumi-select-input":
+                  { height: important "unset"
+                  }
+
+              , "& lumi-select-input-selected-value":
                   { backgroundColor: cssStringHSLA colors.primary3
                   , borderRadius: "3px"
                   , padding: "0 0 0 7px"

--- a/src/Lumi/Components/Textarea.purs
+++ b/src/Lumi/Components/Textarea.purs
@@ -1,10 +1,11 @@
 module Lumi.Components.Textarea where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Data.Nullable (Nullable, toNullable)
 import Effect.Uncurried (mkEffectFn1)
-import JSS (JSS, jss)
+import JSS (JSS, important, jss)
 import Lumi.Components.Input (lumiInputDisabledStyles, lumiInputFocusInvalidStyles, lumiInputFocusStyles, lumiInputHoverStyles, lumiInputInvalidStyles, lumiInputPlaceholderStyles, lumiInputStyles)
 import React.Basic (Component, JSX, createComponent, element, makeStateless)
 import React.Basic.DOM (CSS, css, unsafeCreateDOMComponent)
@@ -87,8 +88,12 @@ styles =
         , touchAction: "manipulation"
         , boxSizing: "border-box"
         , resize: "vertical"
-        , minHeight: "32px"
         , extend: lumiInputStyles
+        , height: important "unset"
+        , minHeight: "40px"
+        , "@media (min-width: 860px)":
+            { minHeight: "32px"
+            }
         , "&:hover": lumiInputHoverStyles
         , "&:invalid": lumiInputInvalidStyles
         , "&:focus":


### PR DESCRIPTION
Workaround for inputs and selects occasionally (and inconsistently) growing an additional 2px internally across browsers.