### PR TITLE
[update] tooltip to accept JSX

### DIFF
--- a/docs/Examples/Tooltip.example.purs
+++ b/docs/Examples/Tooltip.example.purs
@@ -9,6 +9,7 @@ import Lumi.Components.Column (column_)
 import Lumi.Components.Link as Link
 import Lumi.Components.Row (row_)
 import Lumi.Components.Text (body_)
+import Lumi.Components.Text as T
 import Lumi.Components.Example (example)
 import Lumi.Components.Tooltip (tooltip)
 import React.Basic (JSX)
@@ -22,7 +23,7 @@ docs =
         $ tooltip
             { variant: "basic"
             , style: R.css {}
-            , text: [ R.text "Lorem ipsum" ]
+            , text: R.text "Lorem ipsum"
             , content: body_ "Basic example"
             , size: toNullable Nothing
             }
@@ -31,7 +32,7 @@ docs =
         $ tooltip
             { variant: "top"
             , style: R.css {}
-            , text: [ R.text "Lorem ipsum" ]
+            , text: R.text "Lorem ipsum"
             , content: body_ "Top example"
             , size: toNullable Nothing
             }
@@ -40,7 +41,7 @@ docs =
         $ tooltip
             { variant: "bottom"
             , style: R.css {}
-            , text: [ R.text "Lorem ipsum" ]
+            , text: R.text "Lorem ipsum"
             , content: body_ "Bottom example"
             , size: toNullable Nothing
             }
@@ -49,7 +50,7 @@ docs =
         $ tooltip
             { variant: "left"
             , style: R.css {}
-            , text: [ R.text "Lorem ipsum" ]
+            , text: R.text "Lorem ipsum"
             , content: body_ "Left example"
             , size: toNullable Nothing
             }
@@ -60,7 +61,7 @@ docs =
               , tooltip
                   { variant: "top"
                   , style: R.css { padding: "0 2px", textDecoration: "underline" }
-                  , text: [ R.text "Lorem ipsum" ]
+                  , text: R.text "Lorem ipsum"
                   , content: body_ "here"
                   , size: toNullable Nothing
                   }
@@ -73,7 +74,7 @@ docs =
               , tooltip
                   { variant: "top"
                   , style: R.css { padding: "0 2px", textDecoration: "underline" }
-                  , text: [ R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus." ]
+                  , text: R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus."
                   , content: body_ "here"
                   , size: toNullable $ Just $ Large
                   }
@@ -87,14 +88,18 @@ docs =
                   { variant: "top"
                   , style: R.css { padding: "0 2px", textDecoration: "underline" }
                   , text:
-                      [ R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus "
-                      , Link.link Link.defaults
-                          { href = URL "#/link"
-                          , text = R.text "click here"
-                          , target = Just "_blank"
-                          }
-                      , R.text "."
-                      ]
+                      T.text T.body
+                        { style = R.css {}
+                        , children =
+                            [ R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus "
+                            , Link.link Link.defaults
+                                { href = URL "#/link"
+                                , text = R.text "click here"
+                                , target = Just "_blank"
+                                }
+                            , R.text "."
+                            ]
+                        }
                   , content: body_ "here"
                   , size: toNullable $ Just $ Large
                   }

--- a/docs/Examples/Tooltip.example.purs
+++ b/docs/Examples/Tooltip.example.purs
@@ -6,12 +6,15 @@ import Data.Maybe (Maybe(..))
 import Data.Nullable (toNullable)
 import Lumi.Components.Size (Size(..))
 import Lumi.Components.Column (column_)
+import Lumi.Components.Link as Link
 import Lumi.Components.Row (row_)
 import Lumi.Components.Text (body_)
+import Lumi.Components.Text as T
 import Lumi.Components.Example (example)
 import Lumi.Components.Tooltip (tooltip)
 import React.Basic (JSX)
 import React.Basic.DOM as R
+import Web.HTML.History (URL(..))
 
 docs :: JSX
 docs =
@@ -20,7 +23,7 @@ docs =
         $ tooltip
             { variant: "basic"
             , style: R.css {}
-            , text: "Lorem ipsum"
+            , text: R.text "Lorem ipsum"
             , content: body_ "Basic example"
             , size: toNullable Nothing
             }
@@ -29,7 +32,7 @@ docs =
         $ tooltip
             { variant: "top"
             , style: R.css {}
-            , text: "Lorem ipsum"
+            , text: R.text "Lorem ipsum"
             , content: body_ "Top example"
             , size: toNullable Nothing
             }
@@ -38,7 +41,7 @@ docs =
         $ tooltip
             { variant: "bottom"
             , style: R.css {}
-            , text: "Lorem ipsum"
+            , text: R.text "Lorem ipsum"
             , content: body_ "Bottom example"
             , size: toNullable Nothing
             }
@@ -47,7 +50,7 @@ docs =
         $ tooltip
             { variant: "left"
             , style: R.css {}
-            , text: "Lorem ipsum"
+            , text: R.text "Lorem ipsum"
             , content: body_ "Left example"
             , size: toNullable Nothing
             }
@@ -58,7 +61,7 @@ docs =
               , tooltip
                   { variant: "top"
                   , style: R.css { padding: "0 2px", textDecoration: "underline" }
-                  , text: "Lorem ipsum"
+                  , text: R.text "Lorem ipsum"
                   , content: body_ "here"
                   , size: toNullable Nothing
                   }
@@ -71,10 +74,35 @@ docs =
               , tooltip
                   { variant: "top"
                   , style: R.css { padding: "0 2px", textDecoration: "underline" }
-                  , text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus."
+                  , text: R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus."
                   , content: body_ "here"
                   , size: toNullable $ Just $ Large
                   }
               , body_ "for more."
+              ]
+
+    , example
+        $ row_
+              [ body_ "Hello, world see"
+              , tooltip
+                  { variant: "top"
+                  , style: R.css { padding: "0 2px", textDecoration: "underline" }
+                  , text:
+                      T.text T.body
+                        { style = R.css {}
+                        , children =
+                            [ R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus "
+                            , Link.link Link.defaults
+                                { href = URL "#/link"
+                                , text = R.text "click here"
+                                , target = Just "_blank"
+                                }
+                            , R.text "."
+                            ]
+                        }
+                  , content: body_ "here"
+                  , size: toNullable $ Just $ Large
+                  }
+              , body_ "for more (includes link in tooltip)."
               ]
     ]

--- a/docs/Examples/Tooltip.example.purs
+++ b/docs/Examples/Tooltip.example.purs
@@ -9,7 +9,6 @@ import Lumi.Components.Column (column_)
 import Lumi.Components.Link as Link
 import Lumi.Components.Row (row_)
 import Lumi.Components.Text (body_)
-import Lumi.Components.Text as T
 import Lumi.Components.Example (example)
 import Lumi.Components.Tooltip (tooltip)
 import React.Basic (JSX)
@@ -23,7 +22,7 @@ docs =
         $ tooltip
             { variant: "basic"
             , style: R.css {}
-            , text: R.text "Lorem ipsum"
+            , text: [ R.text "Lorem ipsum" ]
             , content: body_ "Basic example"
             , size: toNullable Nothing
             }
@@ -32,7 +31,7 @@ docs =
         $ tooltip
             { variant: "top"
             , style: R.css {}
-            , text: R.text "Lorem ipsum"
+            , text: [ R.text "Lorem ipsum" ]
             , content: body_ "Top example"
             , size: toNullable Nothing
             }
@@ -41,7 +40,7 @@ docs =
         $ tooltip
             { variant: "bottom"
             , style: R.css {}
-            , text: R.text "Lorem ipsum"
+            , text: [ R.text "Lorem ipsum" ]
             , content: body_ "Bottom example"
             , size: toNullable Nothing
             }
@@ -50,7 +49,7 @@ docs =
         $ tooltip
             { variant: "left"
             , style: R.css {}
-            , text: R.text "Lorem ipsum"
+            , text: [ R.text "Lorem ipsum" ]
             , content: body_ "Left example"
             , size: toNullable Nothing
             }
@@ -61,7 +60,7 @@ docs =
               , tooltip
                   { variant: "top"
                   , style: R.css { padding: "0 2px", textDecoration: "underline" }
-                  , text: R.text "Lorem ipsum"
+                  , text: [ R.text "Lorem ipsum" ]
                   , content: body_ "here"
                   , size: toNullable Nothing
                   }
@@ -74,7 +73,7 @@ docs =
               , tooltip
                   { variant: "top"
                   , style: R.css { padding: "0 2px", textDecoration: "underline" }
-                  , text: R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus."
+                  , text: [ R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus." ]
                   , content: body_ "here"
                   , size: toNullable $ Just $ Large
                   }
@@ -88,18 +87,14 @@ docs =
                   { variant: "top"
                   , style: R.css { padding: "0 2px", textDecoration: "underline" }
                   , text:
-                      T.text T.body
-                        { style = R.css {}
-                        , children =
-                            [ R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus "
-                            , Link.link Link.defaults
-                                { href = URL "#/link"
-                                , text = R.text "click here"
-                                , target = Just "_blank"
-                                }
-                            , R.text "."
-                            ]
-                        }
+                      [ R.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor libero non libero consequat, at iaculis diam venenatis. Donec nec porttitor tellus "
+                      , Link.link Link.defaults
+                          { href = URL "#/link"
+                          , text = R.text "click here"
+                          , target = Just "_blank"
+                          }
+                      , R.text "."
+                      ]
                   , content: body_ "here"
                   , size: toNullable $ Just $ Large
                   }

--- a/src/Lumi/Components/List.purs
+++ b/src/Lumi/Components/List.purs
@@ -180,11 +180,15 @@ styles = jss
               , minHeight: "calc(48px + 1px)"
               , padding: "6px 0"
               , borderTop: [ "1px", "solid", cssStringHSLA colors.black4 ]
+              , "@media (max-width: 860px)":
+                  { flexFlow: "column"
+                  }
               , "& > lumi-list-row-cell":
                   { boxSizing: "border-box"
                   , display: "flex"
                   , flexFlow: "column"
                   , justifyContent: "center"
+                  , alignItems: "flex-start"
                   , flex: "1"
                   , maxWidth: "100%"
                   }

--- a/src/Lumi/Components/List.purs
+++ b/src/Lumi/Components/List.purs
@@ -180,15 +180,11 @@ styles = jss
               , minHeight: "calc(48px + 1px)"
               , padding: "6px 0"
               , borderTop: [ "1px", "solid", cssStringHSLA colors.black4 ]
-              , "@media (max-width: 860px)":
-                  { flexFlow: "column"
-                  }
               , "& > lumi-list-row-cell":
                   { boxSizing: "border-box"
                   , display: "flex"
                   , flexFlow: "column"
                   , justifyContent: "center"
-                  , alignItems: "flex-start"
                   , flex: "1"
                   , maxWidth: "100%"
                   }

--- a/src/Lumi/Components/Tooltip.purs
+++ b/src/Lumi/Components/Tooltip.purs
@@ -14,7 +14,7 @@ import React.Basic.DOM (CSS, unsafeCreateDOMComponent)
 type TooltipProps =
   { variant :: String
   , style :: CSS
-  , text :: JSX
+  , text :: Array JSX
   , content :: JSX
   , size :: Nullable Size
   }
@@ -35,7 +35,7 @@ tooltip = makeStateless component render
         , "data-variant": props.variant
         , children:
             [ lumiTooltipTextElement
-                { children: [ props.text ] }
+                { children: props.text }
             , props.content
             ]
         }

--- a/src/Lumi/Components/Tooltip.purs
+++ b/src/Lumi/Components/Tooltip.purs
@@ -14,7 +14,7 @@ import React.Basic.DOM (CSS, unsafeCreateDOMComponent)
 type TooltipProps =
   { variant :: String
   , style :: CSS
-  , text :: String
+  , text :: JSX
   , content :: JSX
   , size :: Nullable Size
   }

--- a/src/Lumi/Components/Tooltip.purs
+++ b/src/Lumi/Components/Tooltip.purs
@@ -14,7 +14,7 @@ import React.Basic.DOM (CSS, unsafeCreateDOMComponent)
 type TooltipProps =
   { variant :: String
   , style :: CSS
-  , text :: Array JSX
+  , text :: JSX
   , content :: JSX
   , size :: Nullable Size
   }
@@ -35,7 +35,7 @@ tooltip = makeStateless component render
         , "data-variant": props.variant
         , children:
             [ lumiTooltipTextElement
-                { children: props.text }
+                { children: [ props.text ] }
             , props.content
             ]
         }


### PR DESCRIPTION
Update `tooltip` component to accept `JSX` (not just explicitly `String`) for it's text content.

This allows usage of links, etc. inside the tooltip content.