### PR TITLE
List, fix alignment on mobile

### DIFF
--- a/src/Lumi/Components/List.purs
+++ b/src/Lumi/Components/List.purs
@@ -209,6 +209,11 @@ styles = jss
                 , justifyContent: "flex-end"
                 , alignItems: "center"
                 }
+            , "@media (max-width: 448px)":
+                { "& > lumi-list-row > lumi-list-row-cell:not(:first-child)":
+                    { alignItems: "flex-end"
+                    }
+                }
             }
       , "lumi-key-value-list":
           { "& lumi-key-value-list-label":

--- a/src/Lumi/Components/List.purs
+++ b/src/Lumi/Components/List.purs
@@ -209,11 +209,6 @@ styles = jss
                 , justifyContent: "flex-end"
                 , alignItems: "center"
                 }
-            , "@media (max-width: 448px)":
-                { "& > lumi-list-row > lumi-list-row-cell":
-                    { alignItems: "flex-end"
-                    }
-                }
             }
       , "lumi-key-value-list":
           { "& lumi-key-value-list-label":


### PR DESCRIPTION
Remove rule that defaults `flex-end` positioning on our row cells for devices smaller than `448px` -- we have a `rightAlignment` prop if users want a list with the columns (not including the first one) to be right-aligned.