### PR TITLE
Modal + mobile Safari full-height bug

### DIFF
--- a/src/Lumi/Components/Modal.purs
+++ b/src/Lumi/Components/Modal.purs
@@ -433,7 +433,10 @@ styles = jss
               , "&:not([data-variant=\"dialog\"])":
                   { "& lumi-modal":
                       { "@media (max-width: 860px)":
-                          { minHeight: "100vh"
+                          { position: "fixed"
+                          , top: "0"
+                          , left: "0"
+                          , minHeight: "100%"
                           , width: "100vw"
                           , maxWidth: "100vw"
                           , "&[data-size=\"small\"], &[data-size=\"medium\"], &[data-size=\"large\"]":

--- a/src/Lumi/Components/Modal.purs
+++ b/src/Lumi/Components/Modal.purs
@@ -436,7 +436,7 @@ styles = jss
                           { position: "fixed"
                           , top: "0"
                           , left: "0"
-                          , minHeight: "100%"
+                          , height: "100%"
                           , width: "100vw"
                           , maxWidth: "100vw"
                           , "&[data-size=\"small\"], &[data-size=\"medium\"], &[data-size=\"large\"]":

--- a/src/Lumi/Components/Modal.purs
+++ b/src/Lumi/Components/Modal.purs
@@ -435,6 +435,8 @@ styles = jss
                       { "@media (max-width: 860px)":
                           { position: "fixed"
                           , top: "0"
+                          , right: "0"
+                          , bottom: "0"
                           , left: "0"
                           , height: "100%"
                           , width: "100vw"

--- a/src/Lumi/Components/Modal.purs
+++ b/src/Lumi/Components/Modal.purs
@@ -422,7 +422,7 @@ styles = jss
                           , paddingRight: "16px"
                           , "& button.lumi":
                               { fontSize: "16px"
-                              , lineHeight: "24px"
+                              , lineHeight: "initial"
                               , padding: "10px 21px 10px"
                               }
                           }


### PR DESCRIPTION
Our modals on mobile iOS Safari have their bottom action buttons cut off by the browser bar. This is a possible solution to avoid having actions/buttons obscured when opening a modal on a iPhone.

<img width="492" alt="Screen Shot 2019-10-23 at 11 47 25 AM" src="https://user-images.githubusercontent.com/632981/67411163-2dd98480-f58b-11e9-8295-fbfce02d5a63.png">
<img width="494" alt="Screen Shot 2019-10-23 at 11 47 33 AM" src="https://user-images.githubusercontent.com/632981/67411171-303bde80-f58b-11e9-94c8-f1d31a315462.png">
