### PR TITLE
Add helper components for common uses of Responsive

### DIFF
--- a/docs/Examples/Responsive.example.purs
+++ b/docs/Examples/Responsive.example.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Lumi.Components.Column (column_)
 import Lumi.Components.Example (example)
-import Lumi.Components.Responsive (desktop, mobile, phone)
+import Lumi.Components.Responsive (desktop, mobile, phone, withMobile)
 import Lumi.Components.Text (body_, p_)
 import React.Basic (JSX)
 
@@ -15,11 +15,17 @@ docs =
       , p_ "Note that phone sized screens still report themselves as \"mobile\" as well."
       , example
           $ column_
-              [ mobile \_ ->
-                  body_ "Mobile: this text only is only rendered on mobile-sized screens."
+              [ withMobile \isMobile ->
+                  body_
+                    if isMobile then
+                      "Mobile: this text renders differently on mobile-sized screens."
+                    else
+                      "Not mobile: this text renders differently on mobile-sized screens."
+              , mobile \_ ->
+                  body_ "Mobile: this text is only rendered on mobile-sized screens."
               , desktop \_ ->
-                  body_ "Desktop: this text only is only rendered on desktop-sized screens."
+                  body_ "Desktop: this text is only rendered on desktop-sized screens."
               , phone \_ ->
-                  body_ "Phone: this text only is only rendered on phone-sized screens."
+                  body_ "Phone: this text is only rendered on phone-sized screens."
               ]
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -3593,12 +3593,12 @@
       }
     },
     "execa": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.3.tgz",
-      "integrity": "sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+      "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.5",
+        "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
         "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
@@ -3607,6 +3607,49 @@
         "p-finally": "^2.0.0",
         "signal-exit": "^3.0.2",
         "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "expand-brackets": {
@@ -3888,9 +3931,9 @@
       }
     },
     "filesize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-4.1.2.tgz",
-      "integrity": "sha512-iSWteWtfNcrWQTkQw8ble2bnonSl7YJImsn9OZKpE2E4IHhXI78eASpDYUljXZZdYj36QsEKjOs/CsiDqmKMJw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-4.2.1.tgz",
+      "integrity": "sha512-bP82Hi8VRZX/TUBKfE24iiUGsB/sfm2WUrwTQyAzQrhO3V9IhcBBNBXMyzLY5orACxRyYJ3d2HeRVX+eFv4lmA==",
       "dev": true
     },
     "fill-range": {
@@ -4140,12 +4183,12 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "dev": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.6.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -4218,8 +4261,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4240,14 +4282,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4262,20 +4302,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4392,8 +4429,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4405,7 +4441,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4420,7 +4455,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4428,14 +4462,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4454,7 +4486,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4535,8 +4566,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4548,7 +4578,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4634,8 +4663,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4671,7 +4699,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4691,7 +4718,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4735,14 +4761,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6153,9 +6177,9 @@
       }
     },
     "log-update": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.2.0.tgz",
-      "integrity": "sha512-KJ6zAPIHWo7Xg1jYror6IUDFJBq1bQ4Bi4wAEp2y/0ScjBBVi/g0thr0sUVhuvuXauWzczt7T2QHghPDNnKBuw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.3.0.tgz",
+      "integrity": "sha512-YSKm5n+YjZoGZT5lfmOqasVH1fIH9xQA9A81Y48nZ99PxAP62vdCCtua+Gcu6oTn0nqtZd/LwRV+Vflo53ZDWA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -6431,9 +6455,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
@@ -6441,12 +6465,12 @@
       }
     },
     "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "dev": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.9.0"
       }
     },
     "mississippi": {
@@ -7617,9 +7641,9 @@
       }
     },
     "psl": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
-      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
       "dev": true
     },
     "public-encrypt": {
@@ -7698,9 +7722,9 @@
       "dev": true
     },
     "purescript": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.13.2.tgz",
-      "integrity": "sha512-HdB8KzEjXDUq1OXLU+FCfjWWX28suNfsrBYqpAbWVKKg6hvJs+fyCc1earfwZeVL/QimL1734AlmhRP0fQrN+A==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.13.4.tgz",
+      "integrity": "sha512-wVvmdHpBJaxkqigkCNEmxvKElech8V+NWQtj0hQdL0Vhcd3SUFKbdIul9sN4ABOsfYIobKk/foI1VZbUuTJZEw==",
       "dev": true,
       "requires": {
         "purescript-installer": "^0.2.0"
@@ -9387,14 +9411,14 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.5",
+        "minipass": "^2.8.6",
         "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prettier": "^1.18.2",
     "pscid": "^2.8.1",
     "pulp": "^13.0.0",
-    "purescript": "^0.13.2",
+    "purescript": "^0.13.3",
     "purescript-psa": "^0.7.3",
     "react-loadable": "^5.5.0",
     "react-media": "^1.8.0",

--- a/src/Lumi/Components/Responsive.purs
+++ b/src/Lumi/Components/Responsive.purs
@@ -38,40 +38,55 @@ minWidthDesktop :: Int
 minWidthDesktop = 860
 
 mobile :: (Unit -> JSX) -> JSX
-mobile = element c <<< { render: _ }
-  -- WARNING: Don't add any arguments the `mobile` function!
+mobile = \render ->
+  element c { render: \isMobile -> if isMobile then render unit else mempty }
+  -- WARNING: Don't add any arguments to the definition of `mobile`!
   --   `c` must be fully applied at module creation!
   where
-  c =
-    unsafePerformEffect do
-      mkMediaComponent "Mobile" useIsMobile
+  c = unsafePerformEffect (mkMediaComponent "Mobile" useIsMobile)
+
+withMobile :: (Boolean -> JSX) -> JSX
+withMobile = element c <<< { render: _ }
+  -- WARNING: Don't add any arguments to the `withMobile` function!
+  --   `c` must be fully applied at module creation!
+  where
+  c = unsafePerformEffect (mkMediaComponent "Mobile" useIsMobile)
 
 phone :: (Unit -> JSX) -> JSX
-phone = element c <<< { render: _ }
-  -- WARNING: Don't add any arguments the `phone` function!
+phone = \render ->
+  element c { render: \isPhone -> if isPhone then render unit else mempty }
+  -- WARNING: Don't add any arguments to the definition of `phone`!
   --   `c` must be fully applied at module creation!
   where
-  c =
-    unsafePerformEffect do
-      mkMediaComponent "Phone" useIsPhone
+  c = unsafePerformEffect (mkMediaComponent "Phone" useIsPhone)
+
+withPhone :: (Boolean -> JSX) -> JSX
+withPhone = element c <<< { render: _ }
+  -- WARNING: Don't add any arguments to the `withPhone` function!
+  --   `c` must be fully applied at module creation!
+  where
+  c = unsafePerformEffect (mkMediaComponent "Phone" useIsPhone)
 
 desktop :: (Unit -> JSX) -> JSX
-desktop = element c <<< { render: _ }
+desktop = \render ->
+  element c { render: \isDesktop -> if isDesktop then render unit else mempty }
   -- WARNING: Don't add any arguments the `desktop` function!
   --   `c` must be fully applied at module creation!
   where
-  c =
-    unsafePerformEffect do
-      mkMediaComponent "Desktop" useIsDesktop
+  c = unsafePerformEffect (mkMediaComponent "Desktop" useIsDesktop)
+
+withDesktop :: (Boolean -> JSX) -> JSX
+withDesktop = element c <<< { render: _ }
+  -- WARNING: Don't add any arguments to the `withDesktop` function!
+  --   `c` must be fully applied at module creation!
+  where
+  c = unsafePerformEffect (mkMediaComponent "Desktop" useIsDesktop)
 
 mkMediaComponent ::
   String ->
   Hook UseMediaQuery Boolean ->
-  Effect (ReactComponent { render :: Unit -> JSX })
+  Effect (ReactComponent { render :: Boolean -> JSX })
 mkMediaComponent name umq = do
   component ("MediaQuery(" <> name <> ")") \{ render } -> React.do
     isMatch <- umq
-    if isMatch then
-      pure (render unit)
-    else
-      mempty
+    pure $ render isMatch


### PR DESCRIPTION
It seems to be all too common a pattern that we write:
```purescript
mobile \_ ->
  ...
  something1
  ...
desktop \_ ->
  ...
  something2
  ...
```
or even
```purescript
mobile \_ -> something true
desktop \_ -> something false
```

This PR adds `with*` variants to responsive components, allowing us to write:
```purescript
withMobile \isMobile ->
  ...
  if isMobile then
    something1
  else
    something2
  ...
```