### PR TITLE
[hotfix] labeled field with constraint

### DIFF
--- a/src/Lumi/Components/LabeledField.purs
+++ b/src/Lumi/Components/LabeledField.purs
@@ -123,12 +123,13 @@ styles = jss
               }
 
           , "& .labeled-field--left":
-              { flex: "3 5 0%"
+              { flex: "0 1 30%"
               , whiteSpace: "nowrap"
               }
 
           , "& .labeled-field--right":
-              { flex: "7 7 0%"
+              { flex: "0 1 70%"
+              , maxWidth: "70%"
               }
 
           , "& .labeled-field--validation-error": labeledFieldValidationErrorStyles


### PR DESCRIPTION
Add constraint on `flex-grow` to our `LabelFields` so they appropriately "squish" text when it reaches beyond the form boundaries.