### PR TITLE
[bugfix] maxWidth fix on force-top labels

### DIFF
--- a/src/Lumi/Components/LabeledField.purs
+++ b/src/Lumi/Components/LabeledField.purs
@@ -114,7 +114,13 @@ styles = jss
               { flexFlow: "column nowrap"
 
               , "& .labeled-field--left":
-                  { whiteSpace: "normal"
+                  { flex: "initial"
+                  , whiteSpace: "normal"
+                  }
+
+              , "& .labeled-field--right":
+                  { flex: "initial"
+                  , maxWidth: "none"
                   }
               }
 


### PR DESCRIPTION
`max-width` constraint should only be on left/right aligned labels, and not applied to the force-top (top/bottom labels).