### PR TITLE
Fix Slat margin in Safari

### DIFF
--- a/src/Lumi/Components2/Slat.purs
+++ b/src/Lumi/Components2/Slat.purs
@@ -48,7 +48,7 @@ slat =
             }
         Just interaction@{ href: Nothing } ->
           E.element R.button'
-            { css: toCSS theme props slatStyle
+            { css: toCSS theme props slatStyleInteractive
             , children: props.content
             , onClick: capture_ interaction.onClick
             , tabIndex: interaction.tabIndex
@@ -56,7 +56,7 @@ slat =
             }
         Just interaction@{ href: Just href } ->
           E.element R.a'
-            { css: toCSS theme props slatStyle
+            { css: toCSS theme props slatStyleInteractive
             , children: props.content
             , onClick: capture_ interaction.onClick
             , tabIndex: interaction.tabIndex
@@ -73,10 +73,13 @@ slat =
     Styles.Slat.Hidden.slat
       >>> styleModifier_ (E.css { appearance: E.none })
 
+  slatStyleInteractive =
+    slatStyle
+      >>> Styles.Slat.Hidden._interactive
+
 _interactive :: SlatInteraction -> PropsModifier SlatProps
 _interactive interaction =
-  Styles.Slat.Hidden._interactive
-    >>> propsModifier
-        _
-          { interaction = Just interaction
-          }
+  propsModifier
+    _
+      { interaction = Just interaction
+      }

--- a/src/Lumi/Styles/Box.purs
+++ b/src/Lumi/Styles/Box.purs
@@ -3,7 +3,7 @@ module Lumi.Styles.Box where
 import Prelude
 import Color (cssStringHSLA)
 import Lumi.Components (PropsModifier)
-import Lumi.Styles (styleModifier, styleModifier_)
+import Lumi.Styles (int, styleModifier, styleModifier_)
 import Lumi.Styles.Theme (LumiTheme(..))
 import React.Basic.Emotion (class IsStyleProperty, css, nested, prop, str)
 
@@ -11,14 +11,16 @@ box :: forall props. PropsModifier props
 box =
   styleModifier_
     $ css
-      { label: str "box"
-      , display: str "flex"
-      , flexDirection: str "column"
-      , boxSizing: str "border-box"
-      , minHeight: str "0"
-      , minWidth: str "min-content"
-      , flex: str "0 0 auto"
-      }
+        { label: str "box"
+        , display: str "flex"
+        , flexDirection: str "column"
+        , boxSizing: str "border-box"
+        , minHeight: int 0
+        , minWidth: str "min-content"
+        , flex: str "0 0 auto"
+        , margin: int 0
+        , padding: int 0
+        }
 
 _row :: forall props. PropsModifier props
 _row =


### PR DESCRIPTION
`<button />` has default margin in Safari. All Boxes now default to zero margin and padding.

Also fixed interactive Slat styles in the case where the prop is specified manually instead of going through the helper function.