### PR TITLE
Adjust margin on unfocused select-native-input

### DIFF
--- a/src/Lumi/Components/Select.purs
+++ b/src/Lumi/Components/Select.purs
@@ -537,7 +537,6 @@ styles = jss
                   { width: 0
                   , minWidth: 0
                   , padding: 0
-                  , margin: 0
                   , flex: "0 1 0%"
                   }
               }


### PR DESCRIPTION
Happened upon this (tiny) apparent bug while trying to debug something else. The `margin: 0` seems to cause some jank when not "in focus" according to CSS, but while `data-focus` is still `true`. Can be reproduced by clicking on this select component (the MultiSelect from the documentation) and then clicking outside of input and holding mouse down.

### Before
![select-before](https://user-images.githubusercontent.com/26548438/72675550-efe9e080-3a53-11ea-989c-f83097e53228.gif)

### After
![select-after](https://user-images.githubusercontent.com/26548438/72675552-f5472b00-3a53-11ea-93f5-9c0f9f2a8a94.gif)
