### PR TITLE
[hotfix] internal-scrolling Modal, margin bottom fix

### DIFF
--- a/src/Lumi/Components/Modal.purs
+++ b/src/Lumi/Components/Modal.purs
@@ -480,7 +480,11 @@ styles = jss
 
                 -- constrain total height while making the intenal content area flexible and scrollable
               , "&[data-variant=\"internal-scrolling\"]":
-                  { "& lumi-modal lumi-modal-content":
+                  { maxHeight: "100%"
+                  , "& lumi-modal":
+                      { height: "100%"
+                      }
+                  , "& lumi-modal lumi-modal-content":
                       { flex: "1 1 auto"
                       , overflowY: "auto"
                       }

--- a/src/Lumi/Components/Modal.purs
+++ b/src/Lumi/Components/Modal.purs
@@ -480,8 +480,7 @@ styles = jss
 
                 -- constrain total height while making the intenal content area flexible and scrollable
               , "&[data-variant=\"internal-scrolling\"]":
-                  { maxHeight: "100%"
-                  , "& lumi-modal lumi-modal-content":
+                  { "& lumi-modal lumi-modal-content":
                       { flex: "1 1 auto"
                       , overflowY: "auto"
                       }


### PR DESCRIPTION
Our Modals with variant `internal-scrolling` have the bottom margin missing; this maintains the margin-bottom w/ internal scrolling behavior.