### PR TITLE
[hotfix] Pill text has non breaking white space

### DIFF
--- a/src/Lumi/Components/Pill.purs
+++ b/src/Lumi/Components/Pill.purs
@@ -48,6 +48,7 @@ styles = jss
           , borderRadius: "20px"
           , fontSize: "13px"
           , border: "1px solid"
+          , whiteSpace: "nowrap"
 
           , "&[data-status=\"active\"]":
               { color: cssStringHSLA colors.accent1


### PR DESCRIPTION
Pill text should be non-breaking (note this might cause unintended affects on parent or siblings e.g. pushing them out of the parent).