### PR TITLE
[hotfix] Block button clicks when loading or disabled

### DIFF
--- a/src/Lumi/Components/Button.purs
+++ b/src/Lumi/Components/Button.purs
@@ -75,7 +75,11 @@ button = makeStateless component render
                   Enabled -> false
                   Disabled -> false
                   Loading -> true
-            , onClick: props.onPress
+            , onClick:
+                case props.buttonState of
+                  Enabled -> props.onPress
+                  Disabled -> mkEffectFn1 mempty
+                  Loading -> mkEffectFn1 mempty
             , style: props.style
             , type: props.type
             }


### PR DESCRIPTION
Is there any case I'm missing where we'd want to register clicks even when a button is `Loading` or `Disabled`?