### PR TITLE
Slat interactive background-color

### DIFF
--- a/docs/Examples2/Slat.example.purs
+++ b/docs/Examples2/Slat.example.purs
@@ -13,7 +13,6 @@ import Lumi.Components.Svg (userSvg)
 import Lumi.Components.Text (h2_, p_)
 import Lumi.Components.Text as Text
 import Lumi.Components2.Box (box)
-import Lumi.Components2.Slat (SlatInteractionType(..))
 import Lumi.Components2.Slat as Slat
 import Lumi.Styles (styleModifier_)
 import Lumi.Styles.Box (FlexAlign(..))
@@ -62,7 +61,6 @@ docs =
               { onClick: window >>= alert "click!"
               , tabIndex: 1
               , href: Nothing
-              , _type: Nothing
               }
           $ _ { content = exampleSlatContent }
       , h2_ "square (default), spaced list, interactive (background color), min-width content"
@@ -71,11 +69,10 @@ docs =
           $ replicate 3
           $ lumiElement Slat.slat
           $ Slat._listSpaced
-          $ Slat._interactive
+          $ Slat._interactiveBackground
               { onClick: window >>= alert "click!"
               , tabIndex: 1
               , href: Nothing
-              , _type: Just BackgroundInteraction
               }
           $ _ { content = exampleSlatContent }
       , h2_ "round, spaced list, non-interactive, min-width 500px"
@@ -96,7 +93,6 @@ docs =
               { onClick: window >>= alert "click!"
               , tabIndex: 1
               , href: Nothing
-              , _type: Nothing
               }
           $ Slat._topBottom
           $ Slat._listCompact
@@ -107,11 +103,10 @@ docs =
           $ fragment
           $ replicate 9
           $ lumiElement Slat.slat
-          $ Slat._interactive
+          $ Slat._interactiveBackground
               { onClick: window >>= alert "click!"
               , tabIndex: 1
               , href: Nothing
-              , _type: Just BackgroundInteraction
               }
           $ Slat._topBottom
           $ Slat._listCompact

--- a/docs/Examples2/Slat.example.purs
+++ b/docs/Examples2/Slat.example.purs
@@ -13,6 +13,7 @@ import Lumi.Components.Svg (userSvg)
 import Lumi.Components.Text (h2_, p_)
 import Lumi.Components.Text as Text
 import Lumi.Components2.Box (box)
+import Lumi.Components2.Slat (SlatInteractionType(..))
 import Lumi.Components2.Slat as Slat
 import Lumi.Styles (styleModifier_)
 import Lumi.Styles.Box (FlexAlign(..))
@@ -61,6 +62,20 @@ docs =
               { onClick: window >>= alert "click!"
               , tabIndex: 1
               , href: Nothing
+              , _type: Nothing
+              }
+          $ _ { content = exampleSlatContent }
+      , h2_ "square (default), spaced list, interactive (background color), min-width content"
+      , example
+          $ fragment
+          $ replicate 3
+          $ lumiElement Slat.slat
+          $ Slat._listSpaced
+          $ Slat._interactive
+              { onClick: window >>= alert "click!"
+              , tabIndex: 1
+              , href: Nothing
+              , _type: Just BackgroundInteraction
               }
           $ _ { content = exampleSlatContent }
       , h2_ "round, spaced list, non-interactive, min-width 500px"
@@ -81,6 +96,22 @@ docs =
               { onClick: window >>= alert "click!"
               , tabIndex: 1
               , href: Nothing
+              , _type: Nothing
+              }
+          $ Slat._topBottom
+          $ Slat._listCompact
+          $ slatExWidth
+          $ _ { content = exampleSlatContent }
+      , h2_ "top/bottom, compact list, interactive (background color), min-width 500px"
+      , example
+          $ fragment
+          $ replicate 9
+          $ lumiElement Slat.slat
+          $ Slat._interactive
+              { onClick: window >>= alert "click!"
+              , tabIndex: 1
+              , href: Nothing
+              , _type: Just BackgroundInteraction
               }
           $ Slat._topBottom
           $ Slat._listCompact

--- a/src/Lumi/Components2/Slat.purs
+++ b/src/Lumi/Components2/Slat.purs
@@ -1,9 +1,9 @@
 module Lumi.Components2.Slat
   ( SlatProps
   , SlatInteraction
-  , SlatInteractionType(..)
   , slat
   , _interactive
+  , _interactiveBackground
   , module Styles.Slat
   ) where
 
@@ -13,10 +13,10 @@ import Data.Newtype (un)
 import Effect (Effect)
 import Effect.Unsafe (unsafePerformEffect)
 import Lumi.Components (LumiComponent, PropsModifier, lumiComponent, propsModifier)
-import Lumi.Styles (styleModifier_, toCSS)
-import Lumi.Styles.Slat (_interactive, _interactiveBg, slat) as Styles.Slat.Hidden
-import Lumi.Styles.Slat hiding (_interactive, _interactiveBg, slat) as Styles.Slat
-import Lumi.Styles.Theme (useTheme)
+import Lumi.Styles (styleModifier, styleModifier_, toCSS)
+import Lumi.Styles.Slat (_interactive, slat) as Styles.Slat.Hidden
+import Lumi.Styles.Slat hiding (_interactive, slat) as Styles.Slat
+import Lumi.Styles.Theme (LumiTheme(..), useTheme)
 import React.Basic.DOM as R
 import React.Basic.DOM.Events (capture_)
 import React.Basic.Emotion as E
@@ -29,15 +29,10 @@ type SlatProps
     , interaction :: Maybe SlatInteraction
     )
 
-data SlatInteractionType
-  = BorderInteraction
-  | BackgroundInteraction
-
 type SlatInteraction
   = { onClick :: Effect Unit
     , tabIndex :: Int
     , href :: Maybe URL
-    , _type :: Maybe SlatInteractionType
     }
 
 slat :: LumiComponent SlatProps
@@ -52,25 +47,17 @@ slat =
             , children: props.content
             , className
             }
-        Just interaction@{ href: Nothing, _type: t } ->
+        Just interaction@{ href: Nothing } ->
           E.element R.button'
-            { css:
-                case t of
-                  Just BorderInteraction -> toCSS theme props slatStyleInteractive
-                  Just BackgroundInteraction -> toCSS theme props slatStyleInteractiveBg
-                  _ -> toCSS theme props slatStyleInteractive
+            { css: toCSS theme props slatStyleInteractive
             , children: props.content
             , onClick: capture_ interaction.onClick
             , tabIndex: interaction.tabIndex
             , className
             }
-        Just interaction@{ href: Just href,  _type: t } ->
+        Just interaction@{ href: Just href } ->
           E.element R.a'
-            { css:
-                case t of
-                  Just BorderInteraction -> toCSS theme props slatStyleInteractive
-                  Just BackgroundInteraction -> toCSS theme props slatStyleInteractiveBg
-                  _ -> toCSS theme props slatStyleInteractive
+            { css: toCSS theme props slatStyleInteractive
             , children: props.content
             , onClick: capture_ interaction.onClick
             , tabIndex: interaction.tabIndex
@@ -91,13 +78,25 @@ slat =
     slatStyle
       >>> Styles.Slat.Hidden._interactive
 
-  slatStyleInteractiveBg =
-    slatStyle
-      >>> Styles.Slat.Hidden._interactiveBg
-
 _interactive :: SlatInteraction -> PropsModifier SlatProps
 _interactive interaction =
   propsModifier
     _
       { interaction = Just interaction
       }
+
+_interactiveBackground :: SlatInteraction -> PropsModifier SlatProps
+_interactiveBackground interaction =
+  propsModifier
+    _
+      { interaction = Just interaction
+      }
+    >>> styleModifier \(LumiTheme theme) ->
+        E.css
+          { "&:hover":
+            E.nested
+              $ E.css
+                  { backgroundColor: E.color theme.colors.primary4
+                  , borderColor: E.color theme.colors.black4
+                  }
+          }

--- a/src/Lumi/Components2/Slat.purs
+++ b/src/Lumi/Components2/Slat.purs
@@ -1,6 +1,7 @@
 module Lumi.Components2.Slat
   ( SlatProps
   , SlatInteraction
+  , SlatInteractionType(..)
   , slat
   , _interactive
   , module Styles.Slat
@@ -13,8 +14,8 @@ import Effect (Effect)
 import Effect.Unsafe (unsafePerformEffect)
 import Lumi.Components (LumiComponent, PropsModifier, lumiComponent, propsModifier)
 import Lumi.Styles (styleModifier_, toCSS)
-import Lumi.Styles.Slat (_interactive, slat) as Styles.Slat.Hidden
-import Lumi.Styles.Slat hiding (_interactive, slat) as Styles.Slat
+import Lumi.Styles.Slat (_interactive, _interactiveBg, slat) as Styles.Slat.Hidden
+import Lumi.Styles.Slat hiding (_interactive, _interactiveBg, slat) as Styles.Slat
 import Lumi.Styles.Theme (useTheme)
 import React.Basic.DOM as R
 import React.Basic.DOM.Events (capture_)
@@ -28,10 +29,15 @@ type SlatProps
     , interaction :: Maybe SlatInteraction
     )
 
+data SlatInteractionType
+  = BorderInteraction
+  | BackgroundInteraction
+
 type SlatInteraction
   = { onClick :: Effect Unit
     , tabIndex :: Int
     , href :: Maybe URL
+    , _type :: Maybe SlatInteractionType
     }
 
 slat :: LumiComponent SlatProps
@@ -46,17 +52,25 @@ slat =
             , children: props.content
             , className
             }
-        Just interaction@{ href: Nothing } ->
+        Just interaction@{ href: Nothing, _type: t } ->
           E.element R.button'
-            { css: toCSS theme props slatStyleInteractive
+            { css:
+                case t of
+                  Just BorderInteraction -> toCSS theme props slatStyleInteractive
+                  Just BackgroundInteraction -> toCSS theme props slatStyleInteractiveBg
+                  _ -> toCSS theme props slatStyleInteractive
             , children: props.content
             , onClick: capture_ interaction.onClick
             , tabIndex: interaction.tabIndex
             , className
             }
-        Just interaction@{ href: Just href } ->
+        Just interaction@{ href: Just href,  _type: t } ->
           E.element R.a'
-            { css: toCSS theme props slatStyleInteractive
+            { css:
+                case t of
+                  Just BorderInteraction -> toCSS theme props slatStyleInteractive
+                  Just BackgroundInteraction -> toCSS theme props slatStyleInteractiveBg
+                  _ -> toCSS theme props slatStyleInteractive
             , children: props.content
             , onClick: capture_ interaction.onClick
             , tabIndex: interaction.tabIndex
@@ -76,6 +90,10 @@ slat =
   slatStyleInteractive =
     slatStyle
       >>> Styles.Slat.Hidden._interactive
+
+  slatStyleInteractiveBg =
+    slatStyle
+      >>> Styles.Slat.Hidden._interactiveBg
 
 _interactive :: SlatInteraction -> PropsModifier SlatProps
 _interactive interaction =

--- a/src/Lumi/Styles/Slat.purs
+++ b/src/Lumi/Styles/Slat.purs
@@ -1,6 +1,5 @@
 module Lumi.Styles.Slat
   ( slat
-  , _interactiveBg
   , module Border
   ) where
 
@@ -30,16 +29,3 @@ slat =
             , textDecoration: unset
             }
         )
-
-_interactiveBg :: forall props. PropsModifier props
-_interactiveBg =
-  Box._interactive
-    >>> Box._focusable
-    >>> styleModifier \(LumiTheme theme) ->
-        css
-          { "&:hover":
-            nested
-              $ css
-                  { backgroundColor: color theme.colors.primary4
-                  }
-          }

--- a/src/Lumi/Styles/Slat.purs
+++ b/src/Lumi/Styles/Slat.purs
@@ -6,13 +6,11 @@ module Lumi.Styles.Slat
 import Prelude
 
 import Lumi.Components (PropsModifier)
-import Lumi.Styles (styleModifier, styleModifier_)
-import Lumi.Styles.Box (FlexAlign(..), _align, _interactive, _justify, _row)
-import Lumi.Styles.Box as Box
+import Lumi.Styles (styleModifier_)
+import Lumi.Styles.Box (FlexAlign(..), _align, _justify, _row)
 import Lumi.Styles.Border (border)
 import Lumi.Styles.Border hiding (border) as Border
-import Lumi.Styles.Theme (LumiTheme(..))
-import React.Basic.Emotion (color, css, str, nested, unset)
+import React.Basic.Emotion (css, str, unset)
 
 slat :: forall props. PropsModifier props
 slat =

--- a/src/Lumi/Styles/Slat.purs
+++ b/src/Lumi/Styles/Slat.purs
@@ -40,6 +40,6 @@ _interactiveBg =
           { "&:hover":
             nested
               $ css
-                  { backgroundColor: color theme.colors.black4
+                  { backgroundColor: color theme.colors.primary4
                   }
           }

--- a/src/Lumi/Styles/Slat.purs
+++ b/src/Lumi/Styles/Slat.purs
@@ -1,16 +1,19 @@
 module Lumi.Styles.Slat
   ( slat
+  , _interactiveBg
   , module Border
   ) where
 
 import Prelude
 
 import Lumi.Components (PropsModifier)
-import Lumi.Styles (styleModifier_)
-import Lumi.Styles.Box (FlexAlign(..), _align, _justify, _row)
+import Lumi.Styles (styleModifier, styleModifier_)
+import Lumi.Styles.Box (FlexAlign(..), _align, _interactive, _justify, _row)
+import Lumi.Styles.Box as Box
 import Lumi.Styles.Border (border)
 import Lumi.Styles.Border hiding (border) as Border
-import React.Basic.Emotion (css, str, unset)
+import Lumi.Styles.Theme (LumiTheme(..))
+import React.Basic.Emotion (color, css, str, nested, unset)
 
 slat :: forall props. PropsModifier props
 slat =
@@ -27,3 +30,16 @@ slat =
             , textDecoration: unset
             }
         )
+
+_interactiveBg :: forall props. PropsModifier props
+_interactiveBg =
+  Box._interactive
+    >>> Box._focusable
+    >>> styleModifier \(LumiTheme theme) ->
+        css
+          { "&:hover":
+            nested
+              $ css
+                  { backgroundColor: color theme.colors.black4
+                  }
+          }


### PR DESCRIPTION
Currently `Slat` using the `interactive` `Border` behavior only updates it's border color on hover, this adds a variant that changes the `Slat` background-color on hover