### PR TITLE
Fix pagination showing 2 buttons with 0 available pages

### DIFF
--- a/docs/Examples/Pagination.example.purs
+++ b/docs/Examples/Pagination.example.purs
@@ -40,6 +40,14 @@ docs = unit # make (createComponent "PaginationExample")
         , example
           $ pagination defaults
               { currentPage = self.state.currentPage
+              , pages = 0
+              , onChange = self.setState <<< flip _{ currentPage = _ }
+              , details = Just $ R.text "0 results"
+              }
+
+        , example
+          $ pagination defaults
+              { currentPage = self.state.currentPage
               , pages = 40
               , onChange = self.setState <<< flip _{ currentPage = _ }
               , focusWindow = 4

--- a/src/Lumi/Components/Pagination.purs
+++ b/src/Lumi/Components/Pagination.purs
@@ -36,7 +36,7 @@ pagination = makeStateless (createComponent "Pagination") render
       let
         boundedPage = clamp 0 (props.pages - 1) props.currentPage
         rangeMin = max 0 (boundedPage - (props.focusWindow / 2))
-        rangeMax = min (props.pages - 1) (boundedPage + (props.focusWindow / 2))
+        rangeMax = max 0 $ min (props.pages - 1) (boundedPage + (props.focusWindow / 2))
 
         prevButton =
           keyed "prev" $ R.li_


### PR DESCRIPTION
Before:
![Screen Shot 2020-04-17 at 13 48 35](https://user-images.githubusercontent.com/2164548/79593666-30d4ae00-80b2-11ea-975c-20a4fd9a6ded.png)

After:
![Screen Shot 2020-04-17 at 13 46 53](https://user-images.githubusercontent.com/2164548/79593609-18649380-80b2-11ea-818e-40b53aa0f938.png)
