### PR TITLE
[hotfix] InputGroup dropdown button's missing arrow

### DIFF
--- a/src/Lumi/Components/InputGroup.purs
+++ b/src/Lumi/Components/InputGroup.purs
@@ -78,7 +78,7 @@ styles = jss
 
           , "& input-group-addon button.lumi":
                 { "&[data-color=\"secondary\"]":
-                    { background: cssStringHSLA colors.transparent
+                    { backgroundColor: cssStringHSLA colors.transparent
                     }
                 , "&:focus, &:hover": { zIndex: ziInputGroup }
                 }


### PR DESCRIPTION
Using `backgroundColor` specified over `background` prevents the arrow (which is coming from a `backgroundImage`) from being hidden on the dropdown button inside of an `InputGroup`.