### PR TITLE
Some improvements to the Upload component

### DIFF
--- a/docs/Examples/Form.example.purs
+++ b/docs/Examples/Form.example.purs
@@ -425,7 +425,13 @@ userForm = ado
         { variant: Upload.Avatar
         , backend:
             { fetch: \id ->
-                pure { id, name: Upload.FileName "avatar", previewUri: Nothing }
+                pure
+                  { id
+                  , name: Upload.FileName "avatar"
+                  , previewUri: Nothing
+                  , readonly: false
+                  }
+            , remove: \_ -> pure true
             , upload: \file -> produceAff \emitter -> do
                 let
                   totalBytes = Int.round $ File.size file

--- a/docs/Examples/Upload.example.purs
+++ b/docs/Examples/Upload.example.purs
@@ -17,11 +17,11 @@ import Effect.Random (randomRange)
 import Effect.Uncurried (runEffectFn2)
 import Lumi.Components.Button (button, primary) as Button
 import Lumi.Components.Column (column, column_)
+import Lumi.Components.Example (example)
 import Lumi.Components.Input as Input
 import Lumi.Components.LabeledField (labeledField, RequiredField(..))
 import Lumi.Components.Text (h2_)
 import Lumi.Components.Upload (FileId(..), FileName(..), UploadVariant(..), defaults, upload)
-import Lumi.Components.Example (example)
 import React.Basic (Component, JSX, createComponent, make)
 import React.Basic.DOM as R
 import React.Basic.DOM.Events (targetChecked)
@@ -117,7 +117,13 @@ docs = unit # make component { initialState, didMount, render }
                       , readonly = self.state.readonly
                       , backend =
                           { fetch: \id@(FileId name) ->
-                              pure { id, name: FileName name, previewUri: Nothing }
+                              pure
+                                { id
+                                , name: FileName name
+                                , previewUri: Nothing
+                                , readonly: false
+                                }
+                          , remove: \_ -> pure true
                           , upload: \file -> produceAff \emitter ->
                               uploadWithRandomPauses emitter file
                           }
@@ -134,10 +140,17 @@ docs = unit # make component { initialState, didMount, render }
                       { value = self.state.files
                       , variant = Files
                       , onChange = send self <<< FileEx
+                      , onClick = \(FileId id) -> Just $ log id
                       , readonly = self.state.readonly
                       , backend =
                           { fetch: \id@(FileId name) ->
-                              pure { id, name: FileName name, previewUri: Nothing }
+                              pure
+                                { id
+                                , name: FileName name
+                                , previewUri: Nothing
+                                , readonly: false
+                                }
+                          , remove: \_ -> pure true
                           , upload: \file -> produceAff \emitter -> do
                               foldMap AVar.read self.state.startUpload
                               void $ foldMap AVar.tryTake self.state.startUpload
@@ -163,7 +176,13 @@ docs = unit # make component { initialState, didMount, render }
                       , readonly = self.state.readonly
                       , backend =
                           { fetch: \id@(FileId name) -> do
-                              pure { id, name: FileName name, previewUri: Nothing }
+                              pure
+                                { id
+                                , name: FileName name
+                                , previewUri: Nothing
+                                , readonly: false
+                                }
+                          , remove: \_ -> pure true
                           , upload: \file -> produceAff \emitter ->
                               uploadWithRandomPauses emitter file
                           }
@@ -182,7 +201,13 @@ docs = unit # make component { initialState, didMount, render }
                       , readonly = self.state.readonly
                       , backend =
                           { fetch: \id@(FileId name) -> do
-                              pure { id, name: FileName name, previewUri: Nothing }
+                              pure
+                                { id
+                                , name: FileName name
+                                , previewUri: Nothing
+                                , readonly: false
+                                }
+                          , remove: \_ -> pure true
                           , upload: \file -> produceAff \emitter ->
                               uploadWithRandomPauses emitter file
                           }

--- a/src/Lumi/Components/Form.purs
+++ b/src/Lumi/Components/Form.purs
@@ -81,7 +81,7 @@ import Lumi.Components.Column (column)
 import Lumi.Components.FetchCache as FetchCache
 import Lumi.Components.Form.Defaults (formDefaults) as Defaults
 import Lumi.Components.Form.Internal (Forest, FormBuilder'(..), FormBuilder, SeqFormBuilder, Tree(..), formBuilder, formBuilder_, invalidate, pruneTree, sequential)
-import Lumi.Components.Form.Internal (Forest(..), FormBuilder', FormBuilder, SeqFormBuilder', SeqFormBuilder, formBuilder, formBuilder_, invalidate, listen, parallel, revalidate, sequential) as Internal
+import Lumi.Components.Form.Internal (Forest, FormBuilder', FormBuilder, SeqFormBuilder', SeqFormBuilder, Tree(..), formBuilder, formBuilder_, invalidate, listen, parallel, revalidate, sequential) as Internal
 import Lumi.Components.Form.Validation (setModified)
 import Lumi.Components.Form.Validation (Validated(..), Validator, _Validated, fromValidated, mustBe, mustEqual, nonEmpty, nonEmptyArray, nonNull, validNumber, validInt, validDate, optional, setFresh, setModified, validated, warn) as Validation
 import Lumi.Components.Input (alignToInput)

--- a/src/Lumi/Components/Form/Defaults.purs
+++ b/src/Lumi/Components/Form/Defaults.purs
@@ -9,6 +9,10 @@ import Prelude
 
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Either (Either(..))
+import Data.Map (Map)
+import Data.Map as Map
+import Data.Set (Set)
+import Data.Set as Set
 import Data.Maybe (Maybe(..))
 import Data.Symbol (class IsSymbol, SProxy(..))
 import Lumi.Components.Form.Validation (Validated(..))
@@ -38,6 +42,8 @@ instance formDefaultsNumber :: FormDefaults Number where formDefaults = 0.0
 instance formDefaultsInt :: FormDefaults Int where formDefaults = 0
 instance formDefaultsString :: FormDefaults String where formDefaults = ""
 instance formDefaultsArray :: FormDefaults (Array a) where formDefaults = []
+instance formDefaultsSet :: FormDefaults (Set a) where formDefaults = Set.empty
+instance formDefaultsMap :: FormDefaults (Map k a) where formDefaults = Map.empty
 
 instance formDefaultsNonEmptyArray :: FormDefaults a => FormDefaults (NonEmptyArray a) where
   formDefaults = pure formDefaults

--- a/src/Lumi/Components/Upload.purs
+++ b/src/Lumi/Components/Upload.purs
@@ -126,7 +126,9 @@ type UploadProps =
 
 type UploadBackend =
   { fetch :: FileId -> Aff FileInfo
-    -- | Allows for running arbitrary 
+    -- | Allows for running an async effect to determine whether the given file
+    -- | should be removed or not. This may be opening a modal window that asks
+    -- | for user confirmation or fetching some remote data.
   , remove :: FileId -> Aff Boolean
   , upload :: File -> Producer Progress Aff (Either Error FileId)
   }

--- a/src/Lumi/Components/Upload.purs
+++ b/src/Lumi/Components/Upload.purs
@@ -875,11 +875,7 @@ styles = jss
                   , flexFlow: "row"
                   , alignItems: "center"
                   , height: "65px"
-                  , borderTop: [ "1px", "solid", cssStringHSLA colors.black4 ]
-
-                  , "&:last-child":
-                      { borderBottom: [ "1px", "solid", cssStringHSLA colors.black4 ]
-                      }
+                  , borderBottom: [ "1px", "solid", cssStringHSLA colors.black4 ]
 
                   , "& > lumi-upload-file-image":
                       { boxSizing: "border-box"

--- a/src/Lumi/Components/Upload.purs
+++ b/src/Lumi/Components/Upload.purs
@@ -31,14 +31,14 @@ import Data.Foldable (foldMap, for_, traverse_)
 import Data.Int (toNumber)
 import Data.Int as Int
 import Data.Map as Map
-import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.Maybe (Maybe(..), fromMaybe, isJust, maybe)
 import Data.MediaType (MediaType(..))
 import Data.Newtype (class Newtype, un)
 import Data.Nullable (Nullable, toNullable)
 import Data.String as String
-import Data.Traversable (for)
+import Data.Traversable (for, sequence_)
 import Effect (Effect)
-import Effect.Aff (Aff, Error, runAff_)
+import Effect.Aff (Aff, Error, launchAff_, runAff_)
 import Effect.Class (liftEffect)
 import Effect.Class.Console (errorShow)
 import Effect.Exception (try)
@@ -79,6 +79,7 @@ type FileInfo =
   { id :: FileId
   , name :: FileName
   , previewUri :: Maybe URI
+  , readonly :: Boolean
   }
 
 type PendingFileInfo =
@@ -114,6 +115,7 @@ type UploadProps =
   , name :: String
   , onBlur :: Nullable EventHandler
   , onChange :: Array FileId -> Effect Unit
+  , onClick :: FileId -> Maybe (Effect Unit)
   , onFocus :: Nullable EventHandler
   , readonly :: Boolean
   , required :: Boolean
@@ -124,6 +126,8 @@ type UploadProps =
 
 type UploadBackend =
   { fetch :: FileId -> Aff FileInfo
+    -- | Allows for running arbitrary 
+  , remove :: FileId -> Aff Boolean
   , upload :: File -> Producer Progress Aff (Either Error FileId)
   }
 
@@ -137,13 +141,20 @@ defaults :: UploadProps
 defaults =
   { allowMultiple: true
   , backend:
-      { fetch: \id@(FileId name) -> pure { id, name: FileName name, previewUri: Nothing }
+      { fetch: \id@(FileId name) -> pure
+          { id
+          , name: FileName name
+          , previewUri: Nothing
+          , readonly: false
+          }
+      , remove: \_ -> pure true
       , upload: \file -> pure (Right (FileId (File.name file)))
       }
   , disabled: false
   , name: ""
   , onBlur: toNullable $ Just $ handler_ $ pure unit
   , onChange: \_ -> pure unit
+  , onClick: \_ -> Nothing
   , onFocus: toNullable $ Just $ handler_ $ pure unit
   , readonly: false
   , required: false
@@ -212,7 +223,7 @@ upload = make component { initialState, render }
             , previewUri
             , progress: Nothing
             }
-          pure { file, name, previewUri }
+          pure { file, name, previewUri, readonly: true }
       let
         handlePending name = forever do
           progress <- await
@@ -221,12 +232,12 @@ upload = make component { initialState, render }
 
         handleCompleteFiles = send self <<< AddCompleteFiles
       runAff_ (either errorShow handleCompleteFiles) do
-        flip parTraverse allowedFiles' \{ file, name, previewUri } -> do
+        flip parTraverse allowedFiles' \{ file, name, previewUri, readonly } -> do
           let var = self.props.backend.upload file
           completeFile <- runProcess (var $$ handlePending name)
           case completeFile of
             Left error -> throwError error
-            Right id -> pure { id, name, previewUri }
+            Right id -> pure { id, name, previewUri, readonly }
 
     send self action = do
       unless self.props.readonly do
@@ -267,7 +278,11 @@ upload = make component { initialState, render }
                 props.onChange $ mergeFileIds (shouldAllowMultiple props) (map _.id files) props.value
 
           RemoveCompleteFile fileId -> do
-            self.props.onChange $ Array.delete fileId self.props.value
+            launchAff_ do
+              shouldRemove <- self.props.backend.remove fileId
+              when shouldRemove $ liftEffect do
+                props <- readProps self
+                props.onChange $ Array.delete fileId props.value
 
     render self@{ props, state, instance_ } =
       FetchCache.multi
@@ -370,7 +385,8 @@ upload = make component { initialState, render }
                   ( stuff.completeFiles <#> \value ->
                       lumiUploadImage
                         { key: un FileName value.name
-                        , onClick: cancel
+                        , onClick: cancelAnd $ sequence_ (self.props.onClick value.id)
+                        , "data-clickable": isJust (self.props.onClick value.id)
                         , style:
                             case value.previewUri <|> Map.lookup value.id stuff.filePreviewCache of
                               Just (URI uri) ->
@@ -388,7 +404,7 @@ upload = make component { initialState, render }
                                   , backgroundSize: "36px 36px"
                                   }
                         , children:
-                            if stuff.readonly
+                            if stuff.readonly || value.readonly
                               then [ empty ]
                               else
                                 [ lumiUploadImageHoverOverlay {}
@@ -403,6 +419,7 @@ upload = make component { initialState, render }
                     in Array.filter (\f -> not Array.elem f.name completeFileNames) stuff.pendingFiles <#> \value ->
                       lumiUploadImage
                         { key: un FileName value.name
+                        , "data-clickable": false
                         , onClick: cancel
                         , style: R.css {}
                         , children:
@@ -447,15 +464,25 @@ upload = make component { initialState, render }
                                           }
                                 }
                             , lumiUploadFileInfo
-                                { children: [ body_ $ un FileName value.name ]
+                                { children:
+                                    [ case self.props.onClick value.id of
+                                        Nothing ->
+                                          body_ $ un FileName value.name
+                                        Just onClick ->
+                                          button linkStyle
+                                            { title = un FileName value.name
+                                            , onPress = cancelAnd onClick
+                                            }
+                                    ]
                                 }
-                            , if stuff.readonly
+                            , if stuff.readonly || value.readonly
                                 then empty
-                                else lumiUploadFileRemove
-                                  { onClick: capture_ $ send self $ RemoveCompleteFile value.id
-                                  , children: icon_ Bin
-                                  , style: R.css {}
-                                  }
+                                else
+                                  lumiUploadFileRemove
+                                    { onClick: capture_ $ send self $ RemoveCompleteFile value.id
+                                    , children: icon_ Bin
+                                    , style: R.css {}
+                                    }
                             ]
                         }
                   )
@@ -523,6 +550,8 @@ upload = make component { initialState, render }
                 Just pendingFileInfo, _ ->
                   lumiUploadAvatarImage
                     { style: R.css {}
+                    , "data-clickable": false
+                    , onClick: cancel
                     , children:
                         [ pendingFileInfo.progress # foldMap \progress ->
                             progressCircle progressDefaults
@@ -542,33 +571,15 @@ upload = make component { initialState, render }
                             , backgroundRepeat: "no-repeat"
                             , backgroundSize: "cover"
                             }
+                        , "data-clickable": isJust (self.props.onClick fileInfo.id)
+                        , onClick: cancelAnd $ sequence_ (self.props.onClick fileInfo.id)
                         , children: []
                         }
                     _ ->
-                      case variant of
-                        Logo ->
-                          lumiUploadAvatarImage
-                            { style: R.css { backgroundColor: cssStringHSLA colors.black4 }
-                            , children: []
-                            }
-                        _ ->
-                          lumiUploadAvatarImage
-                            { style: R.css {}
-                            , children: [ userSvg ]
-                            }
+                      defaultAvatarImage
 
                 _, _ ->
-                  case variant of
-                    Logo ->
-                      lumiUploadAvatarImage
-                        { style: R.css { backgroundColor: cssStringHSLA colors.black4 }
-                        , children: []
-                        }
-                    _ ->
-                      lumiUploadAvatarImage
-                        { style: R.css {}
-                        , children: [ userSvg ]
-                        }
+                  defaultAvatarImage
             , if stuff.readonly
                 then empty
                 else
@@ -590,6 +601,9 @@ upload = make component { initialState, render }
                               Nothing ->
                                 empty
 
+                              Just fileInfo | stuff.readonly || fileInfo.readonly ->
+                                empty
+
                               Just fileInfo ->
                                 button linkStyle
                                   { onPress = capture_ $ send self $ RemoveCompleteFile fileInfo.id
@@ -599,6 +613,23 @@ upload = make component { initialState, render }
                       }
             ]
         }
+      where
+        defaultAvatarImage =
+          case variant of
+            Logo ->
+              lumiUploadAvatarImage
+                { style: R.css { backgroundColor: cssStringHSLA colors.black4 }
+                , "data-clickable": false
+                , onClick: cancel
+                , children: []
+                }
+            _ ->
+              lumiUploadAvatarImage
+                { style: R.css {}
+                , "data-clickable": false
+                , onClick: cancel
+                , children: [ userSvg ]
+                }
 
     lumiUpload = element (R.unsafeCreateDOMComponent "lumi-upload")
     lumiUploadLabel = elementKeyed (R.unsafeCreateDOMComponent "label")
@@ -641,6 +672,9 @@ getEventFiles fileInput = do
 
 cancel :: EventHandler
 cancel = handler (stopPropagation >>> preventDefault) \_ -> pure unit
+
+cancelAnd :: Effect Unit -> EventHandler
+cancelAnd eff = handler (stopPropagation >>> preventDefault) \_ -> eff
 
 unsafeGlobalEventTarget :: EventTarget
 unsafeGlobalEventTarget = unsafePerformEffect do
@@ -790,7 +824,7 @@ styles = jss
               }
 
           , "& > label.lumi-upload + lumi-upload-image-list, & > label.lumi-upload + lumi-upload-file-list":
-                { marginTop: "24px - 8px" -- (gap)
+                { marginTop: "8px" -- (gap)
                 }
 
           , "& > lumi-upload-image-list":
@@ -815,6 +849,10 @@ styles = jss
                   , position: "relative"
                   , width: "128px"
                   , height: "128px"
+
+                  , "&[data-clickable=\"true\"]":
+                      { cursor: "pointer"
+                      }
 
                   , "&:not(:hover)":
                       { "& > lumi-upload-image-hover-overlay, & > lumi-upload-image-remove-icon":
@@ -935,6 +973,9 @@ styles = jss
                   , borderRadius: "40px"
                   , overflow: "hidden"
                   , backgroundColor: cssStringHSLA colors.white
+                  , "&[data-clickable=\"true\"]":
+                      { cursor: "pointer"
+                      }
                   }
               , "& > lumi-upload-avatar-actions":
                   { boxSizing: "border-box"


### PR DESCRIPTION
***This PR contains breaking changes.***

- ~~Remove the `onChange` prop from `Upload` and replace it with `onUpload :: Array FileId -> Effect Unit` and `onRemove :: FileId -> Maybe (Effect Unit)`.~~
    - ~~The `Maybe` in `onRemove` lets us make some files non-removable.~~
- Add a `readonly :: Boolean` field to `FileInfo` that indicates whether a given file may be removed or not.
- Add a `remove :: FileId -> Aff Boolean` field to `UploadBackend` that allows for running an async action to check whether the file should be removed (e.g. a confirmation modal).
- Add the `onClick :: FileId -> Maybe (Effect Unit)` prop to `Upload` so that users can interact with the uploaded files — e.g. for downloading them.
- Add `FormDefaults` instances for `Set` and `Map`.