### PR TITLE
Use link-style button in editable table and Form.Table improvements

### DIFF
--- a/docs/Examples/Form.example.purs
+++ b/docs/Examples/Form.example.purs
@@ -344,7 +344,7 @@ userForm = ado
       )
     $ FT.editableTable
         { addLabel: "Add pet"
-        , addRow: Just $ pure
+        , addRow: Just $ pure $ Just
             { firstName: F.Fresh ""
             , lastName: F.Fresh ""
             , animal: F.Fresh Nothing

--- a/docs/Examples/Form.example.purs
+++ b/docs/Examples/Form.example.purs
@@ -344,7 +344,7 @@ userForm = ado
       )
     $ FT.editableTable
         { addLabel: "Add pet"
-        , defaultValue: Just
+        , addRow: Just $ pure
             { firstName: F.Fresh ""
             , lastName: F.Fresh ""
             , animal: F.Fresh Nothing

--- a/docs/Examples/Form.example.purs
+++ b/docs/Examples/Form.example.purs
@@ -352,6 +352,7 @@ userForm = ado
             , color: Nothing
             }
         , maxRows: top
+        , rowMenu: FT.defaultRowMenu
         , summary: mempty
         , formBuilder: ado
             name <- FT.column_ "Name" ado

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
         font-family: -apple-system, BlinkMacSystemFont, "San Francisco",
           "Roboto", "Droid Sans", Ubuntu, "Helvetica Neue", Helvetica,
           sans-serif;
+        font-size: 1.5em;
         margin: 0;
       }
     </style>

--- a/src/Lumi/Components/Form/Table.purs
+++ b/src/Lumi/Components/Form/Table.purs
@@ -87,6 +87,11 @@ revalidate form props row = (un TableFormBuilder form props).validate row
 editableTable
   :: forall props row result
    . { addLabel :: String
+       -- | Controls the action that is performed when the button for adding a
+       -- | new row is clicked. If this is `Nothing`, the button is not
+       -- | displayed. The async effect wrapped in `Maybe` produces the new row
+       -- | that will be inserted in the table, and, if it's result is
+       -- | `Nothing`, then no rows will be added.
      , addRow :: Maybe (Aff (Maybe row))
      , formBuilder :: TableFormBuilder { readonly :: Boolean | props } row result
      , maxRows :: Int

--- a/src/Lumi/Components/Form/Table.purs
+++ b/src/Lumi/Components/Form/Table.purs
@@ -1,5 +1,6 @@
 module Lumi.Components.Form.Table
   ( TableFormBuilder
+  , revalidate
   , editableTable
   , nonEmptyEditableTable
   , defaultRowMenu
@@ -68,6 +69,16 @@ instance applicativeTableFormBuilder :: Applicative (TableFormBuilder props row)
       { columns: []
       , validate: \_ -> pure a
       }
+
+-- | Revalidate the table form, in order to display error messages or create
+-- | a validated result.
+revalidate
+  :: forall props row result
+   . TableFormBuilder props row result
+  -> props
+  -> row
+  -> Maybe result
+revalidate form props row = (un TableFormBuilder form props).validate row
 
 -- | A `TableFormBuilder` makes a `FormBuilder` for an array where each row has
 -- | columns defined by it.

--- a/src/Lumi/Components/Form/Table.purs
+++ b/src/Lumi/Components/Form/Table.purs
@@ -99,7 +99,10 @@ editableTable
         -> row
         -> Maybe result
         -> JSX
-     , summary :: JSX
+     , summary
+        :: Array row
+        -> Maybe (Array result)
+        -> JSX
      }
   -> FormBuilder
       { readonly :: Boolean | props }
@@ -109,6 +112,7 @@ editableTable { addLabel, addRow, formBuilder: builder, maxRows, rowMenu, summar
   formBuilder \props rows ->
     let
       { columns, validate } = (un TableFormBuilder builder) props
+      validateRows = traverse validate rows
     in
       { edit: \onChange ->
           EditableTable.editableTable
@@ -123,7 +127,7 @@ editableTable { addLabel, addRow, formBuilder: builder, maxRows, rowMenu, summar
                       , flexWrap: "wrap"
                       , justifyContent: "flex-end"
                       }
-                  , children: [ summary ]
+                  , children: [ summary rows validateRows ]
                   }
             , rows: Left $ mapWithIndex Tuple rows
             , onRowAdd:
@@ -146,7 +150,7 @@ editableTable { addLabel, addRow, formBuilder: builder, maxRows, rowMenu, summar
                       render r (onChange <<< ix i)
                   }
             }
-      , validate: traverse validate rows
+      , validate: validateRows
       }
 
 -- | A `TableFormBuilder` makes a `FormBuilder` for a non-empty array where each
@@ -164,7 +168,10 @@ nonEmptyEditableTable
         -> row
         -> Maybe result
         -> JSX
-     , summary :: JSX
+     , summary
+        :: NEA.NonEmptyArray row
+        -> Maybe (NEA.NonEmptyArray result)
+        -> JSX
      }
   -> FormBuilder
       { readonly :: Boolean | props }
@@ -174,6 +181,7 @@ nonEmptyEditableTable { addLabel, addRow, formBuilder: builder, maxRows, rowMenu
   formBuilder \props rows ->
     let
       { columns, validate } = (un TableFormBuilder builder) props
+      validateRows = traverse validate rows
     in
       { edit: \onChange ->
           EditableTable.editableTable
@@ -188,7 +196,7 @@ nonEmptyEditableTable { addLabel, addRow, formBuilder: builder, maxRows, rowMenu
                       , flexWrap: "wrap"
                       , justifyContent: "flex-end"
                       }
-                  , children: [ summary ]
+                  , children: [ summary rows validateRows ]
                   }
             , rows: Right $ mapWithIndex Tuple rows
             , onRowAdd:
@@ -211,7 +219,7 @@ nonEmptyEditableTable { addLabel, addRow, formBuilder: builder, maxRows, rowMenu
                       render r (onChange <<< ix i)
                   }
             }
-      , validate: traverse validate rows
+      , validate: validateRows
       }
 
 -- | Default row menu that displays a bin icon, which, when clicked, deletes the

--- a/src/Lumi/Styles/Button.purs
+++ b/src/Lumi/Styles/Button.purs
@@ -149,6 +149,7 @@ button colo kind state size = case kind of
               [ css
                   { label: str "button"
                   , appearance: none
+                  , outline: none
                   , padding: int 0
                   , background: none
                   , border: none
@@ -172,6 +173,7 @@ button colo kind state size = case kind of
           ( css
               { label: str "button"
               , appearance: none
+              , outline: none
               , minWidth: int 70
               , padding: str "10px 20px"
               , fontSize: int 14


### PR DESCRIPTION
***This PR contains breaking changes.***

- Use link-style button in editable tables
- Add context menu to `Form.Table` via a new `rowMenu` prop
- Allow for using async actions to add new rows in `Form.Table`
- Make form result available for the `summary` in `Form.Table`

![Screen Shot 2020-06-22 at 11 54 25](https://user-images.githubusercontent.com/2164548/85315059-c1ec4a80-b490-11ea-8eac-4c9c1b379229.png)