### PR TITLE
Input fixes

### DIFF
--- a/src/Lumi/Components/Form.purs
+++ b/src/Lumi/Components/Form.purs
@@ -345,7 +345,7 @@ inputBox inputProps = formBuilder_ \{ readonly } s onChange ->
     else Input.input inputProps
            { value = s
            , onChange = capture targetValue (traverse_ onChange)
-           , style = R.css { width: "100%" }
+           , style = R.css { width: "100%" } <> inputProps.style
            }
 
 -- | A simple text box makes a `FormBuilder` for strings
@@ -451,7 +451,7 @@ labeledCheckbox label =
       }
   where
     lumiAlignToInput = element (R.unsafeCreateDOMComponent "lumi-align-to-input")
-    
+
 -- | A form that edits an optional structure represented by group of radio
 -- | buttons, visually oriented in either horizontal or vertical fashion.
 -- |

--- a/src/Lumi/Components/Input.purs
+++ b/src/Lumi/Components/Input.purs
@@ -97,6 +97,8 @@ type InputProps =
   , disabled :: Boolean
   , max :: Nullable Number
   , min :: Nullable Number
+  , maxLength :: Nullable Int
+  , minLength :: Nullable Int
   , step :: Nullable InputStep
   , name :: String
   , onBlur :: Nullable EventHandler
@@ -133,6 +135,8 @@ input = makeStateless component $ element lumiInputElement <<< mapProps
       , indeterminate: props.checked == Indeterminate
       , max: props.max
       , min: props.min
+      , maxLength: props.maxLength
+      , minLength: props.minLength
       , step: toNullable $ map displayStep $ toMaybe props.step
       , name: props.name
       , onBlur: props.onBlur
@@ -156,6 +160,8 @@ text_ =
   , disabled: false
   , max: toNullable Nothing
   , min: toNullable Nothing
+  , maxLength: toNullable Nothing
+  , minLength: toNullable Nothing
   , step: toNullable Nothing
   , name: ""
   , onBlur: toNullable Nothing


### PR DESCRIPTION
- add maxLength/minLength to our `InputProps`
- use input style props with `Form.InputBox`