### PR TITLE
Fix useForm's setModified helper

### DIFF
--- a/docs/Examples/Form.example.purs
+++ b/docs/Examples/Form.example.purs
@@ -6,6 +6,7 @@ import Color (cssStringHSLA)
 import Control.Coroutine.Aff (close, emit, produceAff)
 import Control.MonadZero (guard)
 import Data.Array as Array
+import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Foldable (foldMap)
 import Data.Int as Int
 import Data.Lens (iso)
@@ -127,7 +128,7 @@ mkUserFormExample = do
                   -- from reloading the page on submission.
       { onSubmit: handler preventDefault \_ ->
           case validated of
-            Nothing ->
+            Nothing -> do
               setModified
             Just { firstName, lastName } ->
               setUserDialog \_ -> Just { firstName, lastName }
@@ -199,7 +200,7 @@ type User =
   , height :: Validated String
   , addresses :: Validated (Array Address)
   , pets :: Validated (Array Pet)
-  , leastFavoriteColors :: Array String
+  , leastFavoriteColors :: Validated (Array String)
   , notes :: String
   , avatar :: Maybe Upload.FileId
   }
@@ -214,7 +215,7 @@ type ValidatedUser =
   , height :: Maybe Number
   , addresses :: Array ValidatedAddress
   , pets :: Array ValidatedPet
-  , leastFavoriteColors :: Array String
+  , leastFavoriteColors :: NonEmptyArray String
   , notes :: String
   , avatar :: Maybe Upload.FileId
   }
@@ -315,6 +316,7 @@ userForm = ado
   leastFavoriteColors <-
     F.indent "Least Favorite Colors" Neither
     $ F.focus (prop (SProxy :: SProxy "leastFavoriteColors"))
+    $ F.validated (F.nonEmptyArray "Required")
     $ F.multiSelect show
     $ map (\x -> { label: x, value: x })
     $ [ "Beige"

--- a/src/Lumi/Components/Form/Validation.purs
+++ b/src/Lumi/Components/Form/Validation.purs
@@ -176,7 +176,10 @@ newtype ModifyValidated = ModifyValidated (Validated ~> Validated)
 
 instance modifyValidated :: Mapping ModifyValidated a a => Mapping ModifyValidated (Validated a) (Validated a) where
   mapping m@(ModifyValidated f) = over _Validated (mapping m) <<< f
-else instance modifyValidatedRecord :: (RL.RowToList r xs, MapRecordWithIndex xs (ConstMapping ModifyValidated) r r) => Mapping ModifyValidated {| r} {| r} where
+else instance modifyValidatedRecord ::
+  (RL.RowToList r xs, MapRecordWithIndex xs (ConstMapping ModifyValidated) r r) =>
+  Mapping ModifyValidated {| r} {| r}
+  where
   mapping d = hmap d
 else instance modifyValidatedArray :: Mapping ModifyValidated a a => Mapping ModifyValidated (Array a) (Array a) where
   mapping d = map (mapping d)


### PR DESCRIPTION
@arthurxavierx I found that `useForm`'s `setModified` was getting specialized too soon making it a noop. This seems to fix it (at least for `useForm`, and therefore `useForm'`, but I haven't checked `formState`), but this isn't something I understand well.