### PR TITLE
Replace readInt with readFloat in EditableTable example

### DIFF
--- a/docs/Examples/EditableTable.example.purs
+++ b/docs/Examples/EditableTable.example.purs
@@ -13,7 +13,7 @@ import Data.Nullable as Nullable
 import Data.Number (isNaN)
 import Data.Number.Format (fixed, toStringWith)
 import Effect.Console (log)
-import Global (readInt)
+import Global (readFloat)
 import Lumi.Components.Column (column_)
 import Lumi.Components.DropdownButton (dropdownIcon, dropdownIconDefaults)
 import Lumi.Components.EditableTable (editableTable, editableTableDefaults)
@@ -82,9 +82,10 @@ docs = unit # make component
                 , { label: "Price"
                   , renderCell: \row -> Input.input Input.number
                       { value = show row.price
+                      , step = Nullable.notNull $ Input.Step 0.01
                       , onChange = handler targetValue \value ->
                           updateRow self $ fromMaybe row do
-                            value' <- readInt 10 <$> value
+                            value' <- readFloat <$> value
                             pure if isNaN value'
                               then row
                               else row { price = value' }


### PR DESCRIPTION
Very small change to the documentation: allow non-integer values in the price column for the `EditableTable` example.

<details><summary><strong>GIFs</strong></summary>

### Before
![Kapture 2020-09-27 at 18 53 40](https://user-images.githubusercontent.com/26548438/94378323-bc894680-00f6-11eb-8e5a-c370111851ab.gif)

### After
![Kapture 2020-09-27 at 19 21 28](https://user-images.githubusercontent.com/26548438/94378324-c743db80-00f6-11eb-854b-866b3d497d0d.gif)

</details>