### PR TITLE
Fix select bugs: filter selected options, avoid re-render on focus change

### DIFF
--- a/src/Lumi/Components/Select.purs
+++ b/src/Lumi/Components/Select.purs
@@ -430,7 +430,7 @@ styles = jss
 
           , "&:hover lumi-select-input": lumiInputHoverStyles
 
-          , "&:focus lumi-select-input, & lumi-select-inner[data-focus=\"true\"] lumi-select-input":
+          , "&:focus-within lumi-select-input, & lumi-select-inner[data-focus=\"true\"] lumi-select-input":
               { extend: lumiInputFocusStyles
               , "& lumi-select-input-placeholder":
                   { display: "none"
@@ -541,7 +541,7 @@ styles = jss
                   }
 
                 -- hide the blank input line when not in focus
-              , "& input.select-native-input[value=\"\"]:not(:focus)":
+              , "& lumi-select-inner:not([data-focus=\"true\"]) input.select-native-input[value=\"\"]":
                   { width: 0
                   , minWidth: 0
                   , padding: 0


### PR DESCRIPTION
Related: https://gitlab.com/lumi-tech/lumi/-/issues/5658

- the native input no longer disappears during the mousedown event of selecting an option, keeping the option under the cursor for the mouseup/click event, allowing the selection to complete
- selected options no longer appear in the option list