### PR TITLE
nativeSelect paddingRight

### DIFF
--- a/src/Lumi/Components/NativeSelect.purs
+++ b/src/Lumi/Components/NativeSelect.purs
@@ -108,6 +108,7 @@ styles = jss
 
           , extend: lumiInputStyles
           , padding: "8px 20px 8px 7px"
+          , paddingRight: "calc(10px + 10px + 14px) !important"
           , "@media (min-width: 860px)":
               { padding: "4px 20px 4px 7px"
               }

--- a/src/Lumi/Components/NativeSelect.purs
+++ b/src/Lumi/Components/NativeSelect.purs
@@ -107,10 +107,9 @@ styles = jss
               }
 
           , extend: lumiInputStyles
-          , padding: "8px 20px 8px 7px"
-          , paddingRight: "calc(10px + 14px) !important"
+          , padding: "8px 24px 8px 7px"
           , "@media (min-width: 860px)":
-              { padding: "4px 20px 4px 7px"
+              { padding: "4px 24px 4px 7px"
               }
           , "&:hover": lumiInputHoverStyles
           , "&:invalid": lumiInputInvalidStyles

--- a/src/Lumi/Components/NativeSelect.purs
+++ b/src/Lumi/Components/NativeSelect.purs
@@ -108,7 +108,7 @@ styles = jss
 
           , extend: lumiInputStyles
           , padding: "8px 20px 8px 7px"
-          , paddingRight: "calc(10px + 10px + 14px) !important"
+          , paddingRight: "calc(10px + 14px) !important"
           , "@media (min-width: 860px)":
               { padding: "4px 20px 4px 7px"
               }


### PR DESCRIPTION
Fix padding-right for our `NativeSelect` particularly when text is right-aligned in the select.

Before:
<img width="143" alt="Screen Shot 2021-05-06 at 11 04 04 AM" src="https://user-images.githubusercontent.com/632981/117321051-cb896180-ae5a-11eb-908b-4881fc7df2d7.png">

After:
<img width="157" alt="Screen Shot 2021-05-06 at 11 42 31 AM" src="https://user-images.githubusercontent.com/632981/117327004-2cffff00-ae60-11eb-8261-b4ca011b5aff.png">

