### PR TITLE
Add 'onMobile' combinator

### DIFF
--- a/src/Lumi/Styles/Responsive.purs
+++ b/src/Lumi/Styles/Responsive.purs
@@ -23,3 +23,23 @@ desktopQuery style =
   css
     { "@media (min-width: 860px)": nested style
     }
+
+-- | Create a style modifier that, only in a mobile-sized screen, applies the
+-- | styles accumulated in the modifier passed in as argument.
+-- |
+-- | NOTE: the value passed in as argument must be a props modifier that touches
+-- | no component-specific props, a property that currently defines style
+-- | modifiers.
+onMobile :: StyleModifier -> StyleModifier
+onMobile m =
+  style \theme ->
+    mobileQuery
+      $ toCSS m
+      $ theme
+
+-- | Guard a style so that it's only applied in a mobile screen resolution.
+mobileQuery :: Style -> Style
+mobileQuery style =
+  css
+    { "@media (max-width: 859px)": nested style
+    }


### PR DESCRIPTION
The reasons for only having a `onDesktop` combinator until now were that we wanted to try a mobile-first approach on our product development (which has clearly not caught on or worked very well), and we thought only specifying mobile and more general styles and overriding them with desktop-specific settings was enough.

The second assumption can make it cumbersome to encode specific styling rules, like when the desktop style should use a component's defaults while the mobile one should override them.