### PR TITLE
Image object-fit

### DIFF
--- a/docs/Examples2/Image.example.purs
+++ b/docs/Examples2/Image.example.purs
@@ -7,7 +7,6 @@ import Lumi.Components (($$$))
 import Lumi.Components.Example (example)
 import Lumi.Components.Spacing (Space(..), vspace)
 import Lumi.Components.Text (h4_)
-import Lumi.Components2.Image (ObjectFit(..))
 import Lumi.Components2.Image as Image
 import React.Basic.Classic (JSX)
 
@@ -25,15 +24,15 @@ docs =
         $ Image.image
         $ Image.resize { width: 40, height: 120 }
         $$$ flexo
-    , h4_ "Thumbnail default (will always have a square aspect ratio); and defaults to object-fit: contain"
+    , h4_ "Thumbnail default (will always have a square aspect ratio); and defaults to object-fit: cover"
     , example
         $ Image.thumbnail
         $$$ flexo
-    , h4_ "Thumbnail default (will always have a square aspect ratio); but can be override with object-fit: cover"
+    , h4_ "Thumbnail default (will always have a square aspect ratio); but can be override with object-fit: contain"
     , example
         $ Image.thumbnail
+        $ Image.contain
         $ _ { content = flexo
-            , objectFit = Cover
             }
     , h4_ "Thumbnail + resize 400px"
     , example

--- a/docs/Examples2/Image.example.purs
+++ b/docs/Examples2/Image.example.purs
@@ -7,26 +7,34 @@ import Lumi.Components (($$$))
 import Lumi.Components.Example (example)
 import Lumi.Components.Spacing (Space(..), vspace)
 import Lumi.Components.Text (h4_)
+import Lumi.Components2.Image (ObjectFit(..))
 import Lumi.Components2.Image as Image
 import React.Basic.Classic (JSX)
 
 docs :: JSX
 docs =
-  let flexo = "https://s3.amazonaws.com/lumi-blog/avatars/_x600/flexo.jpg"
+  let flexo = "https://i.picsum.photos/id/985/1000/300.jpg?hmac=t_lmj43iuzwGqZaRMY1ee9udE_pCzfYLgCD49YrCPjw"
+        -- "https://s3.amazonaws.com/lumi-blog/avatars/_x600/flexo.jpg"
   in Array.intercalate (vspace S16)
     [ h4_ "Image default (will respect image's original aspect ratio & dimensions)"
     , example
         $ Image.image
         $$$ flexo
-    , h4_ "Image + resize { width: 120px, height: 40px }, the image will fill the height and width of its parent (object-fit: cover), maintaining its aspect ratio but cropping the image"
+    , h4_ "Image + resize { width: 40px, height: 120px }, the image will fill the height and width of its parent (object-fit: cover), maintaining its aspect ratio but cropping the image"
     , example
         $ Image.image
-        $ Image.resize { width: 120, height: 40 }
+        $ Image.resize { width: 40, height: 120 }
         $$$ flexo
-    , h4_ "Thumbnail default (will always have a square aspect ratio)"
+    , h4_ "Thumbnail default (will always have a square aspect ratio); and defaults to object-fit: contain"
     , example
         $ Image.thumbnail
         $$$ flexo
+    , h4_ "Thumbnail default (will always have a square aspect ratio); but can be override with object-fit: cover"
+    , example
+        $ Image.thumbnail
+        $ _ { content = flexo
+            , objectFit = Cover
+            }
     , h4_ "Thumbnail + resize 400px"
     , example
         $ Image.thumbnail

--- a/src/Lumi/Components2/Image.purs
+++ b/src/Lumi/Components2/Image.purs
@@ -30,7 +30,7 @@ import Data.Traversable (traverse)
 import Data.Tuple.Nested ((/\))
 import Effect.Timer (clearTimeout, setTimeout)
 import Effect.Unsafe (unsafePerformEffect)
-import Lumi.Components (LumiComponent, PropsModifier, lumiComponent, ($$$))
+import Lumi.Components (LumiComponent, PropsModifier, lumiComponent, propsModifier, ($$$))
 import Lumi.Components.Loader (loader)
 import Lumi.Components.Svg (placeholderSvg)
 import Lumi.Components2.Box as Box
@@ -52,6 +52,7 @@ type ImageProps
   = ( component :: Image
     , content :: String
     , placeholder :: Maybe JSX
+    , imgStyle :: Style
     )
 
 -- | An image has no size restrictions
@@ -115,25 +116,25 @@ image =
                                 , objectFit: E.str "cover"
                                 , display: E.str $ if loaded then "block" else "none"
                                 }
-                                <> defaultImageStyle theme
-                                <> props.css theme
+                                <> props.imgStyle
                             , onLoad: handler_ $ setLoaded true
                             , onError: handler_ $ setLoaded true
                             }
                         ]
                 ]
             , className: props.className
-            , css: defaultImageContainerStyle theme
+            , css: defaultImageStyle theme <> props.css theme
             }
     where
       defaults =
         { component: Image
         , content: ""
         , placeholder: Nothing
+        , imgStyle: E.css {}
         }
 
-      defaultImageContainerStyle :: LumiTheme -> Style
-      defaultImageContainerStyle theme@(LumiTheme { colors }) =
+      defaultImageStyle :: LumiTheme -> Style
+      defaultImageStyle theme@(LumiTheme { colors }) =
         E.css
           { boxSizing: E.borderBox
           , overflow: E.hidden
@@ -141,15 +142,9 @@ image =
           , flexFlow: E.column
           , alignItems: E.center
           , justifyContent: E.center
-          }
-
-      defaultImageStyle :: LumiTheme -> Style
-      defaultImageStyle theme@(LumiTheme { colors }) =
-        E.css
-          { border: E.str "1px solid"
+          , border: E.str "1px solid"
           , borderColor: E.color colors.black4
           }
-
 
 data Thumbnail = Thumbnail
 
@@ -157,6 +152,7 @@ type ThumbnailProps
   = ( component :: Thumbnail
     , content :: String
     , placeholder :: Maybe JSX
+    , imgStyle :: Style
     )
 
 -- | A thumbnail can support size restrictions
@@ -170,6 +166,7 @@ thumbnail =
         $ _ { content = props.content
             , placeholder = props.placeholder
             , css = toCSS defaultSize <> props.css
+            , imgStyle = props.imgStyle
             }
 
       where
@@ -177,19 +174,8 @@ thumbnail =
           { component: Thumbnail
           , content: ""
           , placeholder: Nothing
+          , imgStyle: E.css {}
           }
-
-cover :: StyleModifier
-cover =
-  style_ $ E.css
-      { objectFit: E.str "cover"
-      }
-
-contain :: StyleModifier
-contain =
-  style_ $ E.css
-      { objectFit: E.str "contain"
-      }
 
 -- | The `c` type parameter lets us constrain the type of component to which
 -- | an image modifier may be applied
@@ -207,6 +193,20 @@ resize props =
 -- | restricted to only Thumbnail
 round :: ImageModifier Thumbnail
 round = style_ mkRound
+
+cover :: PropsModifier ThumbnailProps
+cover =
+  propsModifier
+    _
+      { imgStyle = E.css { objectFit: E.str "cover" }
+      }
+
+contain :: PropsModifier ThumbnailProps
+contain =
+  propsModifier
+    _
+      { imgStyle = E.css { objectFit: E.str "contain" }
+      }
 
 resizeSquare :: Int -> ImageModifier Thumbnail
 resizeSquare size =

--- a/src/Lumi/Components2/Image.purs
+++ b/src/Lumi/Components2/Image.purs
@@ -196,17 +196,15 @@ round = style_ mkRound
 
 cover :: PropsModifier ThumbnailProps
 cover =
-  propsModifier
-    _
-      { imgStyle = E.css { objectFit: E.str "cover" }
-      }
+  propsModifier  \props -> props
+    { imgStyle = props.imgStyle <> E.css { objectFit: E.str "cover" }
+    }
 
 contain :: PropsModifier ThumbnailProps
 contain =
-  propsModifier
-    _
-      { imgStyle = E.css { objectFit: E.str "contain" }
-      }
+  propsModifier  \props -> props
+    { imgStyle = props.imgStyle <> E.css { objectFit: E.str "contain" }
+    }
 
 resizeSquare :: Int -> ImageModifier Thumbnail
 resizeSquare size =

--- a/src/Lumi/Components2/Image.purs
+++ b/src/Lumi/Components2/Image.purs
@@ -11,11 +11,12 @@ module Lumi.Components2.Image
   , resize
   , resizeSquare
   , round
+  , cover
+  , contain
   , ImageProps
   , ThumbnailProps
   , Image(..)
   , Thumbnail(..)
-  , ObjectFit(..)
   ) where
 
 import Prelude
@@ -38,7 +39,6 @@ import Lumi.Styles.Box (FlexAlign(..))
 import Lumi.Styles.Box as Styles.Box
 import Lumi.Styles.Slat hiding (_interactive,slat) as Styles.Slat
 import Lumi.Styles.Theme (LumiTheme(..), useTheme)
-import React.Basic.DOM (object)
 import React.Basic.DOM as R
 import React.Basic.Emotion as E
 import React.Basic.Events (handler_)
@@ -48,15 +48,10 @@ import Web.HTML.HTMLElement as HTMLElement
 
 data Image = Image
 
-data ObjectFit =
-  Cover
-  | Contain
-
 type ImageProps
   = ( component :: Image
     , content :: String
     , placeholder :: Maybe JSX
-    , objectFit :: ObjectFit
     )
 
 -- | An image has no size restrictions
@@ -117,26 +112,23 @@ image =
                             , css: E.css
                                 { width: E.percent 100.0
                                 , height: E.percent 100.0
-                                , objectFit: E.str $
-                                    case props.objectFit of
-                                      Cover -> "cover"
-                                      Contain -> "contain"
+                                , objectFit: E.str "cover"
                                 , display: E.str $ if loaded then "block" else "none"
                                 }
+                                <> props.css theme
                             , onLoad: handler_ $ setLoaded true
                             , onError: handler_ $ setLoaded true
                             }
                         ]
                 ]
             , className: props.className
-            , css: defaultImageStyle theme <> props.css theme
+            , css: defaultImageStyle theme
             }
     where
       defaults =
         { component: Image
         , content: ""
         , placeholder: Nothing
-        , objectFit: Cover
         }
 
       defaultImageStyle :: LumiTheme -> Style
@@ -159,7 +151,6 @@ type ThumbnailProps
   = ( component :: Thumbnail
     , content :: String
     , placeholder :: Maybe JSX
-    , objectFit :: ObjectFit
     )
 
 -- | A thumbnail can support size restrictions
@@ -173,7 +164,6 @@ thumbnail =
         $ _ { content = props.content
             , placeholder = props.placeholder
             , css = toCSS defaultSize <> props.css
-            , objectFit = props.objectFit
             }
 
       where
@@ -181,8 +171,19 @@ thumbnail =
           { component: Thumbnail
           , content: ""
           , placeholder: Nothing
-          , objectFit: Contain
           }
+
+cover :: StyleModifier
+cover =
+  style_ $ E.css
+      { objectFit: E.str "cover"
+      }
+
+contain :: StyleModifier
+contain =
+  style_ $ E.css
+      { objectFit: E.str "contain"
+      }
 
 -- | The `c` type parameter lets us constrain the type of component to which
 -- | an image modifier may be applied

--- a/src/Lumi/Components2/Image.purs
+++ b/src/Lumi/Components2/Image.purs
@@ -15,6 +15,7 @@ module Lumi.Components2.Image
   , ThumbnailProps
   , Image(..)
   , Thumbnail(..)
+  , ObjectFit(..)
   ) where
 
 import Prelude
@@ -37,6 +38,7 @@ import Lumi.Styles.Box (FlexAlign(..))
 import Lumi.Styles.Box as Styles.Box
 import Lumi.Styles.Slat hiding (_interactive,slat) as Styles.Slat
 import Lumi.Styles.Theme (LumiTheme(..), useTheme)
+import React.Basic.DOM (object)
 import React.Basic.DOM as R
 import React.Basic.Emotion as E
 import React.Basic.Events (handler_)
@@ -46,10 +48,15 @@ import Web.HTML.HTMLElement as HTMLElement
 
 data Image = Image
 
+data ObjectFit =
+  Cover
+  | Contain
+
 type ImageProps
   = ( component :: Image
     , content :: String
     , placeholder :: Maybe JSX
+    , objectFit :: ObjectFit
     )
 
 -- | An image has no size restrictions
@@ -110,7 +117,10 @@ image =
                             , css: E.css
                                 { width: E.percent 100.0
                                 , height: E.percent 100.0
-                                , objectFit: E.str "cover"
+                                , objectFit: E.str $
+                                    case props.objectFit of
+                                      Cover -> "cover"
+                                      Contain -> "contain"
                                 , display: E.str $ if loaded then "block" else "none"
                                 }
                             , onLoad: handler_ $ setLoaded true
@@ -126,6 +136,7 @@ image =
         { component: Image
         , content: ""
         , placeholder: Nothing
+        , objectFit: Cover
         }
 
       defaultImageStyle :: LumiTheme -> Style
@@ -148,6 +159,7 @@ type ThumbnailProps
   = ( component :: Thumbnail
     , content :: String
     , placeholder :: Maybe JSX
+    , objectFit :: ObjectFit
     )
 
 -- | A thumbnail can support size restrictions
@@ -161,6 +173,7 @@ thumbnail =
         $ _ { content = props.content
             , placeholder = props.placeholder
             , css = toCSS defaultSize <> props.css
+            , objectFit = props.objectFit
             }
 
       where
@@ -168,6 +181,7 @@ thumbnail =
           { component: Thumbnail
           , content: ""
           , placeholder: Nothing
+          , objectFit: Contain
           }
 
 -- | The `c` type parameter lets us constrain the type of component to which

--- a/src/Lumi/Components2/Image.purs
+++ b/src/Lumi/Components2/Image.purs
@@ -115,6 +115,7 @@ image =
                                 , objectFit: E.str "cover"
                                 , display: E.str $ if loaded then "block" else "none"
                                 }
+                                <> defaultImageStyle theme
                                 <> props.css theme
                             , onLoad: handler_ $ setLoaded true
                             , onError: handler_ $ setLoaded true
@@ -122,7 +123,7 @@ image =
                         ]
                 ]
             , className: props.className
-            , css: defaultImageStyle theme
+            , css: defaultImageContainerStyle theme
             }
     where
       defaults =
@@ -131,8 +132,8 @@ image =
         , placeholder: Nothing
         }
 
-      defaultImageStyle :: LumiTheme -> Style
-      defaultImageStyle theme@(LumiTheme { colors }) =
+      defaultImageContainerStyle :: LumiTheme -> Style
+      defaultImageContainerStyle theme@(LumiTheme { colors }) =
         E.css
           { boxSizing: E.borderBox
           , overflow: E.hidden
@@ -140,7 +141,12 @@ image =
           , flexFlow: E.column
           , alignItems: E.center
           , justifyContent: E.center
-          , border: E.str "1px solid"
+          }
+
+      defaultImageStyle :: LumiTheme -> Style
+      defaultImageStyle theme@(LumiTheme { colors }) =
+        E.css
+          { border: E.str "1px solid"
           , borderColor: E.color colors.black4
           }
 


### PR DESCRIPTION
Rather than assume object-fit contain vs. cover, allow the consumer to specify how they want the image to fit relative to the container.

Images default to cover.