### PR TITLE
Upload allowMultiple, only show one pending file/image

### DIFF
--- a/src/Lumi/Components/Upload.purs
+++ b/src/Lumi/Components/Upload.purs
@@ -248,7 +248,9 @@ upload = make component { initialState, render }
             runUpload self files
 
           NewPendingFile pendingFileInfo ->
-            self.setState \state -> state { pendingFiles = Array.snoc state.pendingFiles pendingFileInfo }
+            self.setState \state ->
+              if self.props.allowMultiple then state { pendingFiles = Array.snoc state.pendingFiles pendingFileInfo }
+                else state { pendingFiles = [ pendingFileInfo ] }
 
           UpdatePendingFile name progress -> do
             let


### PR DESCRIPTION
Currently if drag/dropping on an upload with `allowMultiple` set to `false` it will show the full array of pending images/files; only show 1 pending image or file if the upload only supports uploading single files. Will defer to the last selected file.